### PR TITLE
Add motion correction

### DIFF
--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/interfaces/__init__.py
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/interfaces/__init__.py
@@ -1,0 +1,1 @@
+from .nagappan_embargo_2023_motioncorrectioninterface import NagappanEmbargo2023MotionCorrectionInterface

--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/interfaces/nagappan_embargo_2023_motioncorrectioninterface.py
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/interfaces/nagappan_embargo_2023_motioncorrectioninterface.py
@@ -1,28 +1,25 @@
 from pathlib import Path
 from typing import Union
 
-from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
-from neuroconv.utils import DeepDict
+from neuroconv import BaseDataInterface
+from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import ImagingExtractorDataChunkIterator
 from pynwb import NWBFile
+from roiextractors import TiffImagingExtractor
 
 from dombeck_lab_to_nwb.nagappan_embargo_2023.utils import get_xy_shifts, add_motion_correction
 
 
-class NagappanEmbargo2023MotionCorrectionInterface(BaseImagingExtractorInterface):
+class NagappanEmbargo2023MotionCorrectionInterface(BaseDataInterface):
     """Data interface for adding the motion corrected image data."""
 
     display_name = "NagappanEmbargo2023MotionCorrection"
     associated_suffixes = (".tif", ".mat")
     info = "Custom interface for motion corrected imaging data."
 
-    ExtractorName = "TiffImagingExtractor"
-
     def __init__(
         self,
         file_path: Union[str, Path],
         xy_shifts_file_path: Union[str, Path],
-        sampling_frequency: float,
-        photon_series_name: str = "TwoPhotonSeriesCorrected",
         verbose: bool = True,
     ):
         """
@@ -34,46 +31,33 @@ class NagappanEmbargo2023MotionCorrectionInterface(BaseImagingExtractorInterface
             The path to the motion corrected imaging data (.tif file).
         xy_shifts_file_path : Union[str, Path]
             The path to the xy shifts file (.mat file).
-        sampling_frequency : float
-            The sampling frequency of the imaging data.
-        photon_series_name : str, optional
-            The name of the corrected photon series to add, by default "TwoPhotonSeriesCorrected".
         """
-        self.xy_shifts_file_path = xy_shifts_file_path
-        self.photon_series_name = photon_series_name
-        super().__init__(file_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
-
-    def get_metadata(self) -> DeepDict:
-
-        metadata = super().get_metadata()
-        two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
-
-        two_photon_series_metadata.update(
-            name=f"{self.photon_series_name}", description="Motion corrected two-photon imaging data."
-        )
-
-        return metadata
+        super().__init__(file_path=file_path, xy_shifts_file_path=xy_shifts_file_path, verbose=verbose)
 
     def add_to_nwbfile(
         self,
         nwbfile: NWBFile,
         metadata: dict,
-        photon_series_index: int = 0,
+        sampling_frequency: float = None,
+        corrected_image_stack_name: str = "CorrectedImageStack",
         stub_test: bool = False,
     ) -> None:
 
-        super().add_to_nwbfile(
-            nwbfile=nwbfile,
-            metadata=metadata,
-            stub_test=stub_test,
-            parent_container="processing/ophys",
-            photon_series_index=photon_series_index,
+        xy_shifts = get_xy_shifts(self.source_data["xy_shifts_file_path"])
+        # Sampling frequency is required for the extractor, but we will write with the timestamps from the original data
+        imaging_extractor = TiffImagingExtractor(
+            file_path=self.source_data["file_path"], sampling_frequency=sampling_frequency
         )
-
-        xy_translation = get_xy_shifts(self.xy_shifts_file_path)
-        raw_two_photon_series_name = self.photon_series_name.replace("Corrected", "")
+        corrected = (
+            imaging_extractor.get_video(end_frame=100)
+            if stub_test
+            else ImagingExtractorDataChunkIterator(
+                imaging_extractor=imaging_extractor,
+            )
+        )
         add_motion_correction(
             nwbfile=nwbfile,
-            xy_shifts=xy_translation,
-            original_two_photon_series_name=raw_two_photon_series_name,
+            corrected=corrected,
+            xy_shifts=xy_shifts[:100, :] if stub_test else xy_shifts,
+            corrected_image_stack_name=corrected_image_stack_name,
         )

--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/interfaces/nagappan_embargo_2023_motioncorrectioninterface.py
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/interfaces/nagappan_embargo_2023_motioncorrectioninterface.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+from typing import Union
+
+from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
+from neuroconv.utils import DeepDict
+from pynwb import NWBFile
+
+from dombeck_lab_to_nwb.nagappan_embargo_2023.utils import get_xy_shifts, add_motion_correction
+
+
+class NagappanEmbargo2023MotionCorrectionInterface(BaseImagingExtractorInterface):
+    """Data interface for adding the motion corrected image data."""
+
+    display_name = "NagappanEmbargo2023MotionCorrection"
+    associated_suffixes = (".tif", ".mat")
+    info = "Custom interface for motion corrected imaging data."
+
+    ExtractorName = "TiffImagingExtractor"
+
+    def __init__(
+        self,
+        file_path: Union[str, Path],
+        xy_shifts_file_path: Union[str, Path],
+        sampling_frequency: float,
+        photon_series_name: str = "TwoPhotonSeriesCorrected",
+        verbose: bool = True,
+    ):
+        """
+        Interface for motion corrected imaging data.
+
+        Parameters
+        ----------
+        file_path : Union[str, Path]
+            The path to the motion corrected imaging data (.tif file).
+        xy_shifts_file_path : Union[str, Path]
+            The path to the xy shifts file (.mat file).
+        sampling_frequency : float
+            The sampling frequency of the imaging data.
+        photon_series_name : str, optional
+            The name of the corrected photon series to add, by default "TwoPhotonSeriesCorrected".
+        """
+        self.xy_shifts_file_path = xy_shifts_file_path
+        self.photon_series_name = photon_series_name
+        super().__init__(file_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
+
+    def get_metadata(self) -> DeepDict:
+
+        metadata = super().get_metadata()
+        two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
+
+        two_photon_series_metadata.update(
+            name=f"{self.photon_series_name}", description="Motion corrected two-photon imaging data."
+        )
+
+        return metadata
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict,
+        photon_series_index: int = 0,
+        stub_test: bool = False,
+    ) -> None:
+
+        super().add_to_nwbfile(
+            nwbfile=nwbfile,
+            metadata=metadata,
+            stub_test=stub_test,
+            parent_container="processing/ophys",
+            photon_series_index=photon_series_index,
+        )
+
+        xy_translation = get_xy_shifts(self.xy_shifts_file_path)
+        raw_two_photon_series_name = self.photon_series_name.replace("Corrected", "")
+        add_motion_correction(
+            nwbfile=nwbfile,
+            xy_shifts=xy_translation,
+            original_two_photon_series_name=raw_two_photon_series_name,
+        )

--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/nagappan_embargo_2023_convert_session.py
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/nagappan_embargo_2023_convert_session.py
@@ -1,6 +1,6 @@
 """Primary script to run to convert an entire session for of data using the NWBConverter."""
 from pathlib import Path
-from typing import Union
+from typing import Union, Optional
 
 from dateutil import tz
 from neuroconv.utils import load_dict_from_file, dict_deep_update
@@ -13,6 +13,8 @@ def session_to_nwb(
     scanimage_file_pattern: str,
     suite2p_folder_path: Union[str, Path],
     nwbfile_path: Union[str, Path],
+    channel_1_motion_correction_file_path: Optional[Union[str, Path]] = None,
+    channel_2_motion_correction_file_path: Optional[Union[str, Path]] = None,
     stub_test: bool = False,
 ):
     """
@@ -28,6 +30,10 @@ def session_to_nwb(
         The folder containing the Suite2p output.
     nwbfile_path : Union[str, Path]
         The path to the NWB file to be created.
+    channel_1_motion_correction_file_path : Union[str, Path], optional
+        The path to the motion corrected imaging data for channel 1 (.tif file), by default None.
+    channel_2_motion_correction_file_path : Union[str, Path], optional
+        The path to the motion corrected imaging data for channel 2 (.tif file), by default None.
     stub_test : bool, optional
         Whether to run a stub test, by default False.
 
@@ -39,6 +45,8 @@ def session_to_nwb(
         folder_path=scanimage_folder_path,
         file_pattern=scanimage_file_pattern,
         suite2p_folder_path=suite2p_folder_path,
+        channel_1_motion_correction_file_path=channel_1_motion_correction_file_path,
+        channel_2_motion_correction_file_path=channel_2_motion_correction_file_path,
         verbose=True,
     )
 
@@ -87,6 +95,10 @@ if __name__ == "__main__":
     # The folder containing the Suite2p output.
     suite2p_folder_path = root_folder_path / "suite2p"
 
+    # The path to the motion corrected imaging data for channel 1 and channel 2.
+    channel_1_motion_correction_file_path = root_folder_path / "2620749R2_231211_00001_ch1_mot_corrected_x2.tif"
+    channel_2_motion_correction_file_path = root_folder_path / "2620749R2_231211_00001_ch2_mot_corrected_x2.tif"
+
     # The path to the NWB file to be created.
     nwbfile_path = Path("/Volumes/LaCie/CN_GCP/Dombeck/nwbfiles/2620749R2_231211.nwb")
 
@@ -96,6 +108,8 @@ if __name__ == "__main__":
         scanimage_folder_path=scanimage_folder_path,
         scanimage_file_pattern=scanimage_file_pattern,
         suite2p_folder_path=suite2p_folder_path,
+        channel_1_motion_correction_file_path=channel_1_motion_correction_file_path,
+        channel_2_motion_correction_file_path=channel_2_motion_correction_file_path,
         nwbfile_path=nwbfile_path,
         stub_test=stub_test,
     )

--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/nagappan_embargo_2023_notes.md
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/nagappan_embargo_2023_notes.md
@@ -14,6 +14,10 @@ In each TIF the video shape is (4000, 512, 512) for single channel, and (8000, 5
 "Channel 1" is recorded from cell bodies and "Channel 2" is recorded from axons located in the striatum.
 The excitation wavelengths for the two channels are: 920 nm for Channel 1 (Green) and 1070 nm for Channel 2 (Red).
 
+## Motion correction
+
+Motion correction was performed for both channels. The motion corrected imaging data is saved in a separate TIF file for each channel.
+The x, y shifts (in the unit of pixels) for each frame are saved in a separate MAT file for each channel.
 
 ![Alt text](dual_channel_tif.png)
 

--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/nagappan_embargo_2023_requirements.txt
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/nagappan_embargo_2023_requirements.txt
@@ -1,2 +1,3 @@
 neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@add_multifile_scanimage
 neuroconv[scanimage, suite2p]
+pymatreader>=0.0.32

--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/nagappan_embargo_2023nwbconverter.py
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/nagappan_embargo_2023nwbconverter.py
@@ -1,10 +1,15 @@
 """Primary NWBConverter class for this dataset."""
 from pathlib import Path
+from typing import Optional, Union
 
 from natsort import natsorted
 from neuroconv import NWBConverter
 from neuroconv.datainterfaces import ScanImageSinglePlaneMultiFileImagingInterface, Suite2pSegmentationInterface
+from neuroconv.tools.nwb_helpers import get_default_backend_configuration, configure_backend
 from neuroconv.utils import FolderPathType
+from pynwb import NWBFile
+
+from dombeck_lab_to_nwb.nagappan_embargo_2023.interfaces import NagappanEmbargo2023MotionCorrectionInterface
 
 
 class NagappanEmbargo2023NWBConverter(NWBConverter):
@@ -15,6 +20,8 @@ class NagappanEmbargo2023NWBConverter(NWBConverter):
         folder_path: FolderPathType,
         file_pattern: str,
         suite2p_folder_path: FolderPathType,
+        channel_1_motion_correction_file_path: Optional[Union[str, Path]] = None,
+        channel_2_motion_correction_file_path: Optional[Union[str, Path]] = None,
         verbose: bool = False,
     ):
         from roiextractors import ScanImageTiffSinglePlaneImagingExtractor
@@ -42,3 +49,42 @@ class NagappanEmbargo2023NWBConverter(NWBConverter):
             verbose=verbose,
             plane_segmentation_name="PlaneSegmentationChannel1",
         )
+
+        # Add motion correction
+        if channel_1_motion_correction_file_path:
+            xy_shifts_file_name = Path(channel_1_motion_correction_file_path).stem + "_shifts.mat"
+            xy_shifts_file_path = channel_1_motion_correction_file_path.parent / xy_shifts_file_name
+            assert xy_shifts_file_path.exists(), f"The xy shifts file '{xy_shifts_file_path}' does not exist."
+            self.data_interface_objects["MotionCorrectionChannel1"] = NagappanEmbargo2023MotionCorrectionInterface(
+                file_path=channel_1_motion_correction_file_path,
+                xy_shifts_file_path=xy_shifts_file_path,
+                verbose=verbose,
+            )
+
+        if channel_2_motion_correction_file_path:
+            xy_shifts_file_name = Path(channel_2_motion_correction_file_path).stem + "_shifts.mat"
+            xy_shifts_file_path = channel_2_motion_correction_file_path.parent / xy_shifts_file_name
+            assert xy_shifts_file_path.exists(), f"The xy shifts file '{xy_shifts_file_path}' does not exist."
+            self.data_interface_objects["MotionCorrectionChannel2"] = NagappanEmbargo2023MotionCorrectionInterface(
+                file_path=channel_2_motion_correction_file_path,
+                xy_shifts_file_path=xy_shifts_file_path,
+                verbose=verbose,
+            )
+
+    def add_to_nwbfile(self, nwbfile: NWBFile, metadata, conversion_options: Optional[dict] = None) -> None:
+
+        if "MotionCorrectionChannel1" in conversion_options:
+            conversion_options["MotionCorrectionChannel1"].update(
+                corrected_image_stack_name="CorrectedImageStackChannel1",
+                sampling_frequency=30.0421,
+            )
+        if "MotionCorrectionChannel2" in conversion_options:
+            conversion_options["MotionCorrectionChannel2"].update(
+                corrected_image_stack_name="CorrectedImageStackChannel2",
+                sampling_frequency=30.0421,
+            )
+
+        super().add_to_nwbfile(nwbfile=nwbfile, metadata=metadata, conversion_options=conversion_options)
+
+        backend_configuration = get_default_backend_configuration(nwbfile=nwbfile, backend="hdf5")
+        configure_backend(nwbfile=nwbfile, backend_configuration=backend_configuration)

--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/utils/__init__.py
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/utils/__init__.py
@@ -1,0 +1,1 @@
+from .motion_correction import add_motion_correction, get_xy_shifts

--- a/src/dombeck_lab_to_nwb/nagappan_embargo_2023/utils/motion_correction.py
+++ b/src/dombeck_lab_to_nwb/nagappan_embargo_2023/utils/motion_correction.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pymatreader
+from neuroconv.tools import get_module
+from pynwb import NWBFile, TimeSeries
+from pynwb.ophys import MotionCorrection, CorrectedImageStack, TwoPhotonSeries
+
+
+def add_motion_correction(
+    nwbfile: NWBFile,
+    corrected: np.ndarray,
+    xy_shifts: np.ndarray,
+    corrected_image_stack_name: str,
+) -> None:
+    """Add motion correction data to the NWBFile.
+
+    Parameters
+    ----------
+    nwbfile: NWBFile
+        The NWBFile where the motion correction time series will be added to.
+    corrected: numpy.ndarray
+        The corrected imaging data.
+    xy_shifts: numpy.ndarray
+        The x, y shifts for the imaging data.
+    corrected_image_stack_name: str
+        The name of the corrected image stack to be added to the MotionCorrection container.
+    """
+
+    name_suffix = corrected_image_stack_name.replace("CorrectedImageStack", "")
+    original_two_photon_series_name = f"TwoPhotonSeries{name_suffix}"
+    assert (
+        original_two_photon_series_name in nwbfile.acquisition
+    ), f"The two photon series '{original_two_photon_series_name}' does not exist in the NWBFile."
+
+    original_two_photon_series = nwbfile.acquisition[original_two_photon_series_name]
+
+    timestamps = original_two_photon_series.timestamps
+    assert timestamps is not None, "The timestamps for the original two photon series must be set."
+    assert len(xy_shifts) == len(timestamps), "The length of the xy shifts must match the length of the timestamps."
+    xy_translation = TimeSeries(
+        name="xy_translation",  # name must be 'xy_translation'
+        data=xy_shifts,
+        description=f"The x, y shifts for the {original_two_photon_series_name} imaging data.",
+        unit="px",
+        timestamps=timestamps,
+    )
+
+    corrected_two_photon_series = TwoPhotonSeries(
+        name="corrected",  # name must be 'corrected'
+        data=corrected,
+        imaging_plane=original_two_photon_series.imaging_plane,
+        timestamps=timestamps,
+        unit="n.a.",
+    )
+
+    corrected_image_stack = CorrectedImageStack(
+        name=corrected_image_stack_name,
+        corrected=corrected_two_photon_series,
+        original=original_two_photon_series,
+        xy_translation=xy_translation,
+    )
+
+    ophys = get_module(nwbfile, "ophys")
+    if "MotionCorrection" not in ophys.data_interfaces:
+        motion_correction = MotionCorrection(name="MotionCorrection")
+        ophys.add(motion_correction)
+    else:
+        motion_correction = ophys.data_interfaces["MotionCorrection"]
+
+    motion_correction.add_corrected_image_stack(corrected_image_stack)
+
+
+def get_xy_shifts(file_path: str) -> np.ndarray:
+    """Get the x, y (column, row) shifts from the motion correction file.
+
+    Parameters
+    ----------
+    file_path: str
+        The path to the motion correction file.
+
+    Returns
+    -------
+    motion_correction: numpy.ndarray
+        The first column is the x shifts. The second column is the y shifts.
+    """
+    xy_shifts_data = pymatreader.read_mat(file_path)
+    xy_translation = np.column_stack((xy_shifts_data["xshifts"], xy_shifts_data["yshifts"]))
+    return xy_translation


### PR DESCRIPTION
Add motion corrected image data
- add `MotionCorrection` to ophys processing module
- add `CorrectedImageStack` for Green and Red channel and store it in `MotionCorrection`
- The 'corrected' field in `CorrectedImageStack` that corresponds to the motion corrected imaging data must be named 'corrected' (see related [discussion](https://github.com/NeurodataWithoutBorders/pynwb/issues/1305))