### PR TITLE
Update fiber metadata

### DIFF
--- a/src/dombeck_lab_to_nwb/azcorra2023/interfaces/picoscope_timeseriesinterface.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/interfaces/picoscope_timeseriesinterface.py
@@ -58,14 +58,14 @@ class PicoscopeTimeSeriesInterface(BaseDataInterface):
         metadata["NWBFile"].update(session_start_time=session_start_time)
 
         metadata["PicoScopeTimeSeries"] = dict(
-            FluorescenceGreen=dict(
-                name="FluorescenceGreen",
-                description="The fluorescence traces from Green channel collected at 4000 Hz by Picoscope.",
+            FluorescenceFiber1=dict(
+                name="FluorescenceFiber1",
+                description="The fluorescence traces from Fiber1 collected at 4000 Hz by Picoscope.",
                 unit="Volts",
             ),
-            FluorescenceRed=dict(
-                name="FluorescenceRed",
-                description="The fluorescence traces from Red channel collected at 4000 Hz by Picoscope.",
+            FluorescenceFiber2=dict(
+                name="FluorescenceFiber2",
+                description="The fluorescence traces from Fiber2 collected at 4000 Hz by Picoscope.",
                 unit="Volts",
             ),
             Velocity=dict(

--- a/src/dombeck_lab_to_nwb/azcorra2023/metadata/azcorra2023_fiber_photometry_metadata.yaml
+++ b/src/dombeck_lab_to_nwb/azcorra2023/metadata/azcorra2023_fiber_photometry_metadata.yaml
@@ -4,62 +4,55 @@ Ophys:
        name: FiberPhotometryTable
        description: Contains the metadata for the fiber photometry experiment.
     FiberPhotometryResponseSeries:
-      - name: FiberPhotometryResponseSeriesGreen
-        description: Green fluorescence collected during 470 nm illumination re-binned to 100 Hz
+      - name: FiberPhotometryResponseSeriesGreenFiber1
+        description: Raw green fluorescence collected during 470 nm illumination re-binned to 100 Hz and acquired with Fiber1
         indicator: GCaMP6f
-        optical_fiber: chGreen
+        optical_fiber: Fiber1
         excitation_source: ExcitationSource470
         photodetector: PhotodetectorPMT
         dichroic_mirror: DichroicMirrorGreen
         excitation_filter: OpticalFilter470
         emission_filter: EmissionFilterGreen
-      - name: FiberPhotometryResponseSeriesGreenIsosbestic
-        description: Green fluorescence collected at its isosbestic wavelength (405 nm) re-binned to 100 Hz
+      - name: FiberPhotometryResponseSeriesGreenIsosbesticFiber1
+        description: Raw green fluorescence collected at its isosbestic wavelength (405 nm) re-binned to 100 Hz and acquired with Fiber1
         indicator: GCaMP6f
-        optical_fiber: chGreen
+        optical_fiber: Fiber1
         excitation_source: ExcitationSource405
         photodetector: PhotodetectorPMT
         dichroic_mirror: DichroicMirrorGreen
         excitation_filter: OpticalFilter405
         emission_filter: EmissionFilterGreen
-#      - name: FiberPhotometryResponseSeriesRed
-#        description: Red fluorescence collected during 470 nm illumination re-binned to 100 Hz
-#        indicator: mCherry
-#        optical_fiber: chRed
-#        excitation_source: ExcitationSource470
-#        photodetector: PhotodetectorPMT
-#        dichroic_mirror: DichroicMirror
-#        excitation_filter: OpticalFilter470
-#      - name: FiberPhotometryResponseSeriesRedIsosbestic
-#        description: Red fluorescence collected during 405 nm illumination re-binned to 100 Hz
-#        indicator: mCherry
-#        optical_fiber: chRed
-#        excitation_source: ExcitationSource405
-#        photodetector: PhotodetectorPMT
-#        dichroic_mirror: DichroicMirror
-#        excitation_filter: OpticalFilter405
-    DfOverF:
-      FiberPhotometryResponseSeries:
-        - name: DfOverFFiberPhotometryResponseSeriesGreen
-          description: DF/F from green fluorescence traces collected during 470 nm illumination.
-        - name: DfOverFFiberPhotometryResponseSeriesGreenIsosbestic
-          description: DF/F from green fluorescence traces collected at its isosbestic wavelength (405 nm).
-#        - name: DfOverFFiberPhotometryResponseSeriesRed
-#          description: DF/F from red fluorescence traces collected during 470 nm illumination.
-#        - name: DfOverFFiberPhotometryResponseSeriesRedIsosbestic
+      - name: FiberPhotometryResponseSeriesGreenFiber2
+        description: Raw green fluorescence collected during 470 nm illumination re-binned to 100 Hz and acquired with Fiber2
+        indicator: GCaMP6f
+        optical_fiber: Fiber2
+        excitation_source: ExcitationSource470
+        photodetector: PhotodetectorPMT
+        dichroic_mirror: DichroicMirrorGreen
+        excitation_filter: OpticalFilter470
+        emission_filter: EmissionFilterGreen
+      - name: FiberPhotometryResponseSeriesGreenIsosbesticFiber2
+        description: Raw green fluorescence collected at its isosbestic wavelength (405 nm) re-binned to 100 Hz and acquired with Fiber2
+        indicator: GCaMP6f
+        optical_fiber: Fiber2
+        excitation_source: ExcitationSource405
+        photodetector: PhotodetectorPMT
+        dichroic_mirror: DichroicMirror
+        excitation_filter: OpticalFilter405
+        emission_filter: EmissionFilterGreen
     OpticalFibers:
-      - name: chGreen  # the name of the fiber in the .mat file
-        description: The optical fiber used to record the GCaMP fluorescence.
+      - name: Fiber1
+        description: The optical fiber used to record the GCaMP fluorescence
         manufacturer: Doric
         model: MFP_200/230/900-0.57_1.5m_FC-FLT_LAF
         numerical_aperture: 0.57
         core_diameter_in_um: 200.0
-#      - name: chRed # the name of the fiber in the .mat file
-#        description: The optical fiber used to record the red fluorescence.
-#        manufacturer: Doric
-#        model: MFP_200/230/900-0.57_1.5m_FC-FLT_LAF
-#        numerical_aperture: 0.57
-#        core_diameter_in_um: 200.0
+      - name: Fiber2
+        description: The second optical fiber used to record the GCaMP fluorescence
+        manufacturer: Doric
+        model: MFP_200/230/900-0.57_1.5m_FC-FLT_LAF
+        numerical_aperture: 0.57
+        core_diameter_in_um: 200.0
     ExcitationSources:
       - name: ExcitationSource470
         description: |
@@ -124,7 +117,3 @@ Ophys:
         label: AAV-GCaMP6f
         injection_location: SNc
         injection_coordinates_in_mm: [-3.25, 1.55, -3.8]
-#      - name: mCherry
-#        label: AAV5-EF1α-DIO-mCherry
-#        injection_location: SNc
-#        injection_coordinates_in_mm: [1.45, -3.15, -3.1]

--- a/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/add_fiber_photometry.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/add_fiber_photometry.py
@@ -44,6 +44,7 @@ def add_fiber_photometry_series(
     rate: float,
     fiber_photometry_series_name: str,
     table_region_ind: int = 0,
+    unit: str = "F",
     parent_container: Literal["acquisition", "processing/ophys"] = "acquisition",
 ):
     fiber_photometry_metadata = metadata["Ophys"]["FiberPhotometry"]
@@ -80,13 +81,15 @@ def add_fiber_photometry_series(
 
     location = fiber_metadata["location"]
     coordinates = fiber_metadata["coordinates"]
-    fiber_depth_in_mm = fiber_metadata["depth"]
+    fiber_depth_in_mm = fiber_metadata["fiber_depth_in_mm"]
 
     trace_description = trace_metadata["description"]
     trace_description += f" from {location} region at {fiber_depth_in_mm / 1000} meters depth."
     trace_metadata["description"] = trace_description
 
-    fiber_metadata = {k: v for k, v in fiber_metadata.items() if k not in ["location", "coordinates", "depth"]}
+    fiber_metadata = {
+        k: v for k, v in fiber_metadata.items() if k not in ["location", "coordinates", "fiber_depth_in_mm", "label"]
+    }
     add_photometry_device(nwbfile, device_metadata=fiber_metadata, device_type="OpticalFiber")
 
     indicator_to_add = trace_metadata["indicator"]
@@ -180,7 +183,7 @@ def add_fiber_photometry_series(
         name=trace_metadata["name"],
         description=trace_metadata["description"],
         data=data,
-        unit="F",
+        unit=unit,
         rate=rate,
         fiber_photometry_table_region=fiber_photometry_table_region,
     )

--- a/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/process_extra_metadata.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/process_extra_metadata.py
@@ -35,8 +35,8 @@ def process_extra_metadata(
         sex=processed_photometry_data["Gen"].upper(),
     )
 
-    location_fiber_1 = processed_photometry_data["chG"]
-    location_fiber_2 = processed_photometry_data["chR"]
+    location_fiber_1 = processed_photometry_data["chG"].lower()
+    location_fiber_2 = processed_photometry_data["chR"].lower()
     allen_location_fiber_1 = allen_location_mapping.get(location_fiber_1, None)
     allen_location_fiber_2 = allen_location_mapping.get(location_fiber_2, None)
 

--- a/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/process_extra_metadata.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/process_extra_metadata.py
@@ -38,6 +38,10 @@ def process_extra_metadata(
     location_fiber_1 = processed_photometry_data["chG"].lower()
     location_fiber_2 = processed_photometry_data["chR"].lower()
     allen_location_fiber_1 = allen_location_mapping.get(location_fiber_1, None)
+    if allen_location_fiber_1 is None:
+        raise ValueError(
+            f"The location of the first fiber ({location_fiber_1}) is not recognized. Please update it using the allen_location_mapping argument."
+        )
     allen_location_fiber_2 = allen_location_mapping.get(location_fiber_2, None)
 
     # Update the metadata for the first fiber

--- a/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/process_extra_metadata.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/process_extra_metadata.py
@@ -1,12 +1,15 @@
 from copy import deepcopy
 from pathlib import Path
 
-import numpy as np
 from neuroconv.utils import FilePathType, DeepDict
 from pymatreader import read_mat
 
 
-def process_extra_metadata(file_path: FilePathType, metadata: DeepDict):
+def process_extra_metadata(
+    file_path: FilePathType,
+    metadata: DeepDict,
+    allen_location_mapping: dict,
+):
     """
     Process the extra metadata from the processed photometry data ("data6").
 
@@ -16,6 +19,8 @@ def process_extra_metadata(file_path: FilePathType, metadata: DeepDict):
         The path to the processed photometry data file.
     metadata : DeepDict
         The metadata dictionary to update with the extra metadata.
+    allen_location_mapping : dict
+        A mapping of the location names in the processed photometry data to the Allen Brain Atlas location names.
     """
 
     extra_metadata = deepcopy(metadata)
@@ -30,27 +35,35 @@ def process_extra_metadata(file_path: FilePathType, metadata: DeepDict):
         sex=processed_photometry_data["Gen"].upper(),
     )
 
+    location_fiber_1 = processed_photometry_data["chG"]
+    location_fiber_2 = processed_photometry_data["chR"]
+    allen_location_fiber_1 = allen_location_mapping.get(location_fiber_1, None)
+    allen_location_fiber_2 = allen_location_mapping.get(location_fiber_2, None)
+
+    # Update the metadata for the first fiber
     fiber_photometry_metadata = extra_metadata["Ophys"]["FiberPhotometry"]
-
     fibers_metadata = fiber_photometry_metadata["OpticalFibers"]
-
-    fiber_depth_in_mm = processed_photometry_data["depthG"]
-    # Update the metadata for the green fiber
+    fiber_description = fibers_metadata[0]["description"]
+    fiber_description += f"from the {allen_location_fiber_1} brain region."
     fibers_metadata[0].update(
+        description=fiber_description,
         coordinates=processed_photometry_data["RecLocGmm"],
-        depth=fiber_depth_in_mm,
-        location="SNc" if fiber_depth_in_mm > 3.0 else "Str",
+        fiber_depth_in_mm=processed_photometry_data["depthG"],
+        location=allen_location_fiber_1,
     )
 
-    if np.isnan(processed_photometry_data["depthR"]):
-        # For single fiber experiment the red fiber depth is NaN
+    if allen_location_fiber_2 is None:
+        fibers_metadata.pop(1)
         return extra_metadata
 
-    fiber_red_depth_in_mm = processed_photometry_data["depthG"]
+    # Update the metadata for the second fiber
+    fiber_2_description = fibers_metadata[1]["description"]
+    fiber_2_description += f"from the {allen_location_fiber_2} brain region."
     fibers_metadata[1].update(
+        description=fiber_2_description,
         coordinates=processed_photometry_data["RecLocRmm"],
-        depth=fiber_red_depth_in_mm,
-        location="SNc" if fiber_red_depth_in_mm > 3.0 else "Str",
+        fiber_depth_in_mm=processed_photometry_data["depthR"],
+        location=allen_location_fiber_1,
     )
 
     return extra_metadata


### PR DESCRIPTION
- Updates how the location of the fiber is accessed, now using the "chG" and "chR" variables from the processed photometry data
- Updates the fiber metadata
- Small fix added to processed fiber photometry interface, when we're adding the df/f traces now the interface can create the references for the fiber photometry table if the raw traces are missing from a session.
