### PR TITLE
Add extra fiber photometry metadata

### DIFF
--- a/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
@@ -374,15 +374,15 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
 
     def add_analysis(self, nwbfile: NWBFile) -> None:
         event_types_table = EventTypesTable(
-            name="EventTypes",
+            name="PeakFluorescenceEventTypes",
             description="Contains the type of events.",
         )
 
         event_names_mapping = dict(
-            peaksG="Large transient peaks for green fluorescence",
-            peaksR="Large transient peaks for red fluorescence",
-            peaksGRun="Large transient peaks occurring during running periods for green fluorescence",
-            peaksRRun="Large transient peaks occurring during running periods for red fluorescence",
+            peaksG="Large transient peaks for Fiber 1 fluorescence",
+            peaksR="Large transient peaks for Fiber 2 fluorescence",
+            peaksGRun="Large transient peaks occurring during running periods for Fiber 1 fluorescence",
+            peaksRRun="Large transient peaks occurring during running periods for Fiber 2 fluorescence",
         )
 
         for event_name, event_type_description in event_names_mapping.items():
@@ -397,7 +397,7 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
             return
 
         events = EventsTable(
-            name="Events",
+            name="PeakFluorescenceEvents",
             description="Contains the onset times of events.",
             target_tables={"event_type": event_types_table},
         )
@@ -430,7 +430,7 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
 
         peak_events_table = events.from_dataframe(
             peak_events_to_add,
-            name="Events",
+            name="PeakFluorescenceEvents",
             table_description="Contains the onset times of large fluorescence peaks.",
         )
         peak_events_table.event_type.table = event_types_table

--- a/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/process_extra_metadata.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/process_extra_metadata.py
@@ -38,31 +38,58 @@ def process_extra_metadata(
     location_fiber_2 = processed_photometry_data["chR"].lower()
     allen_location_fiber_1 = allen_location_mapping.get(location_fiber_1, None)
     allen_location_fiber_2 = allen_location_mapping.get(location_fiber_2, None)
+    is_dual_fiber = allen_location_fiber_1 is not None and allen_location_fiber_2 is not None
 
     # Update the metadata for the first fiber
     fiber_photometry_metadata = extra_metadata["Ophys"]["FiberPhotometry"]
     fibers_metadata = fiber_photometry_metadata["OpticalFibers"]
 
+    recording_target_type_mapping = {1: "axons in striatum", 0: "cell bodies in SNc"}
+
     if allen_location_fiber_1 is not None:
         fiber_description = fibers_metadata[0]["description"]
-        fiber_description += f"from the {allen_location_fiber_1} brain region."
+        fiber_description += f" from the {allen_location_fiber_1} brain region."
+
+        recording_target_type = recording_target_type_mapping.get(processed_photometry_data["exStr"][0], "unknown")
+
         fibers_metadata[0].update(
             description=fiber_description,
             coordinates=processed_photometry_data["RecLocGmm"],
             fiber_depth_in_mm=processed_photometry_data["depthG"],
             location=allen_location_fiber_1,
             label="chGreen",  # the name of the channel in the .mat file
+            recording_target_type=recording_target_type,
+            baseline_fluorescence=processed_photometry_data["base"][0]
+            if is_dual_fiber
+            else processed_photometry_data["base"],
+            normalized_fluorescence=processed_photometry_data["norm"][0]
+            if is_dual_fiber
+            else processed_photometry_data["norm"],
+            signal_to_noise_ratio=processed_photometry_data["sig2noise"][0],
+            cross_correlation_with_acceleration=processed_photometry_data["Acc405"][0],
         )
 
     if allen_location_fiber_2 is not None:
         fiber_2_description = fibers_metadata[1]["description"]
         fiber_2_description += f" from the {allen_location_fiber_2} brain region."
+
+        recording_target_type = recording_target_type_mapping.get(processed_photometry_data["exStr"][1], "unknown")
+
         fibers_metadata[1].update(
             description=fiber_2_description,
             coordinates=processed_photometry_data["RecLocRmm"],
             fiber_depth_in_mm=processed_photometry_data["depthR"],
             location=allen_location_fiber_2,
             label="chRed",  # the name of the channel in the .mat file
+            recording_target_type=recording_target_type,
+            baseline_fluorescence=processed_photometry_data["base"][1]
+            if is_dual_fiber
+            else processed_photometry_data["base"],
+            normalized_fluorescence=processed_photometry_data["norm"][1]
+            if is_dual_fiber
+            else processed_photometry_data["norm"],
+            signal_to_noise_ratio=processed_photometry_data["sig2noise"][1],
+            cross_correlation_with_acceleration=processed_photometry_data["Acc405"][1],
         )
 
     # keep only those fibers metadata that have location information


### PR DESCRIPTION
1. Adds more fiber photometry metadata (from the processed fiber photometry file) to the `FiberPhotometryTable`:

- baseline_fluorescence: "The baseline fluorescence value for each fiber."
- normalized_fluorescence: The normalized fluorescence value for each fiber.",
- recording_target_type: "Defines whether recordings are made in axons vs cell bodies.",
-signal_to_noise_ratio: "The signal to noise ratio for each fiber.",
-cross_correlation_with_acceleration: "The cross-correlation between ΔF/F and acceleration."
example snippet:
<img width="762" alt="Screenshot 2024-05-23 at 13 52 24 (2)" src="https://github.com/catalystneuro/dombeck-lab-to-nwb/assets/24475788/6ee7bb30-3403-4737-95df-600c0b77622c">

2. Renamed events table that holds the peak fluorescence event onset times and corrected the description

We can discuss on the mid-way if they want to add more, they have some "exclusion criteria" metrics as well, see at the bottom of #1 (all variables that start with "ex")
