### PR TITLE
Align the `starting_time` of the processed fiber photometry data

### DIFF
--- a/src/dombeck_lab_to_nwb/azcorra2023/azcorra2023nwbconverter.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/azcorra2023nwbconverter.py
@@ -29,3 +29,11 @@ class Azcorra2023NWBConverter(NWBConverter):
 
         backend_configuration = get_default_backend_configuration(nwbfile=nwbfile, backend="hdf5")
         configure_backend(nwbfile=nwbfile, backend_configuration=backend_configuration)
+
+    def temporally_align_data_interfaces(self):
+        """
+        Align the starting time of processed fiber photometry data after cropping.
+        """
+        processed_interface = self.data_interface_objects["ProcessedFiberPhotometry"]
+        aligned_starting_time = processed_interface.get_starting_time()
+        processed_interface.set_aligned_starting_time(aligned_starting_time=aligned_starting_time)

--- a/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
@@ -43,7 +43,9 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
         self._processed_photometry_data = processed_photometry_data["data"]
         self._timestamps = None
         self._sampling_frequency = 100.0
-        self._crop_start = processed_photometry_data["cropStart"]
+        crop_point = processed_photometry_data["cropStart"]
+        # If the crop point is a list, it means that the end of the recording was cropped as well
+        self._crop_start = crop_point[0] if isinstance(crop_point, np.ndarray) else crop_point
 
     def get_starting_time(self) -> float:
         """

--- a/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
@@ -50,7 +50,7 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
     def get_starting_time(self) -> float:
         """
         Return the starting time of the processed photometry data.
-        If the start of the picoscope recording had artefacts, the corrupted segment was cut of manually cropping point
+        If the start of the picoscope recording had artefacts, the corrupted segment was cut off manually and the cropping point
         was saved as "cropStart". We are using this value to align the starting time of the processed data with the
         picoscope data.
         """

--- a/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
@@ -43,6 +43,18 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
         self._processed_photometry_data = processed_photometry_data["data"]
         self._timestamps = None
         self._sampling_frequency = 100.0
+        self._crop_start = processed_photometry_data["cropStart"]
+
+    def get_starting_time(self) -> float:
+        """
+        Return the starting time of the processed photometry data.
+        If the start of the picoscope recording had artefacts, the corrupted segment was cut of manually cropping point
+        was saved as "cropStart". We are using this value to align the starting time of the processed data with the
+        picoscope data.
+        """
+        if self._crop_start == 1:
+            return 0.0
+        return self._crop_start / self._sampling_frequency
 
     def get_metadata(self) -> dict:
         metadata = super().get_metadata()
@@ -76,12 +88,7 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
 
     def get_original_timestamps(self) -> np.ndarray:
         processed_photometry_data = read_mat(filename=str(self.file_path))["data6"]["data"]
-        traces = (
-            processed_photometry_data["chGreen"]
-            if "chGreen" in processed_photometry_data
-            else processed_photometry_data["chRed"]
-        )
-        num_frames = len(traces)
+        num_frames = len(processed_photometry_data["chMov"])
         return np.arange(num_frames) / self._sampling_frequency
 
     def get_timestamps(self, stub_test: bool = False) -> np.ndarray:
@@ -105,9 +112,13 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
         ), f"Velocity data not found in {self.source_data['file_path']}."
         velocity = self._processed_photometry_data["chMov"]
         velocity_metadata = behavior_metadata["Velocity"]
+
+        timestamps = self.get_timestamps()
+
         velocity_ts = TimeSeries(
             data=velocity,
             rate=self._sampling_frequency,
+            starting_time=timestamps[0],
             **velocity_metadata,
         )
 
@@ -119,6 +130,7 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
         acceleration_ts = TimeSeries(
             data=acceleration,
             rate=self._sampling_frequency,
+            starting_time=timestamps[0],
             **acceleration_metadata,
         )
 
@@ -155,6 +167,8 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
         """
         ophys_module = get_module(nwbfile=nwbfile, name="ophys", description=f"Processed fiber photometry data.")
 
+        timestamps = self.get_timestamps(stub_test=stub_test)
+
         for series_ind, (channel_name, series_name) in enumerate(
             channel_name_to_photometry_series_name_mapping.items()
         ):
@@ -181,6 +195,7 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
                     data=data_to_add,
                     unit="n.a.",
                     rate=self._sampling_frequency,
+                    starting_time=timestamps[0],
                     fiber_photometry_table_region=fiber_photometry_table_region,
                 )
 
@@ -196,7 +211,7 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
                     nwbfile=nwbfile,
                     metadata=metadata,
                     data=data_to_add,
-                    rate=self._sampling_frequency,
+                    timestamps=timestamps,
                     fiber_photometry_series_name=series_name,
                     table_region_ind=series_ind,
                     parent_container="processing/ophys",

--- a/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/interfaces/azcorra2023_processedfiberphotometryinterface.py
@@ -197,7 +197,6 @@ class Azcorra2023ProcessedFiberPhotometryInterface(BaseTemporalAlignmentInterfac
                     metadata=metadata,
                     data=data_to_add,
                     rate=self._sampling_frequency,
-                    unit="n.a.",
                     fiber_photometry_series_name=series_name,
                     table_region_ind=series_ind,
                     parent_container="processing/ophys",

--- a/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/add_fiber_photometry.py
+++ b/src/dombeck_lab_to_nwb/azcorra2023/photometry_utils/add_fiber_photometry.py
@@ -43,7 +43,6 @@ def add_fiber_photometry_series(
     rate: float,
     fiber_photometry_series_name: str,
     table_region_ind: int = 0,
-    unit: str = "F",
     parent_container: Literal["acquisition", "processing/ophys"] = "acquisition",
 ):
     fiber_photometry_metadata = metadata["Ophys"]["FiberPhotometry"]
@@ -211,7 +210,7 @@ def add_fiber_photometry_series(
         name=trace_metadata["name"],
         description=trace_metadata["description"],
         data=data,
-        unit=unit,
+        unit="n.a.",
         rate=rate,
         fiber_photometry_table_region=fiber_photometry_table_region,
     )


### PR DESCRIPTION
After looking at the converted files I noticed that some recordings might be cropped (the picoscope data was longer than the processed data). After digging into their [processing code](https://github.com/DombeckLab/Azcorra2023/blob/main/Fiber%20photometry%20data%20analysis/Data%20pre%20processing/data_processing.m#L196) I found out that in some cases they were cropping the beginning of the recording and saving the crop point named "cropStart". 

I'm using this variable to align the starting time of the processed interface, so we are saving the processed behavior data and fiber photometry data with the correct starting time.