### PR TITLE
Add conversion for LRRK2 dataset (`chen2026`)

### DIFF
--- a/src/dombeck_lab_to_nwb/chen2026/README.md
+++ b/src/dombeck_lab_to_nwb/chen2026/README.md
@@ -72,3 +72,11 @@ You can run the conversion of a single session with the following command:
 ```bash
 python src/dombeck_lab_to_nwb/chen2026/convert_session.py
 ```
+
+### Running the batch conversion
+
+You can run the conversion of all 27 sessions with the following command:
+
+```bash
+python src/dombeck_lab_to_nwb/chen2026/convert_all_sessions.py
+```

--- a/src/dombeck_lab_to_nwb/chen2026/README.md
+++ b/src/dombeck_lab_to_nwb/chen2026/README.md
@@ -1,0 +1,74 @@
+# src/dombeck_lab_to_nwb/chen2026
+NWB conversion scripts for the LRRK2 Dataset from the Dombeck lab (2026-07).
+
+## Installation
+
+The package can be installed directly from GitHub, which has the advantage that the source code can be modified if you need to amend some of the code we originally provided to adapt to future experimental differences.
+To install the conversion from GitHub you will need to use `git` ([installation instructions](https://github.com/git-guides/install-git)). We also recommend the installation of `conda` ([installation instructions](https://docs.conda.io/en/latest/miniconda.html)) as it contains
+all the required machinery in a single and simple install.
+
+From a terminal (note that conda should install one in your system) you can do the following:
+
+```
+git clone https://github.com/catalystneuro/dombeck-lab-to-nwb
+cd dombeck-lab-to-nwb
+conda env create --file src/dombeck_lab_to_nwb/chen2026/environment.yaml
+conda activate chen2026
+```
+
+This creates a [conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/environments.html) which isolates the conversion code from your system libraries.
+Then, you can install the repository in [editable mode](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs):
+
+```
+pip install -e . --no-deps
+```
+
+The `--no-deps` flag skips the root `requirements.txt` so that the dependencies already installed
+by the conda environment (in particular `neuroconv` from the GitHub main branch) are not
+overwritten by an older PyPI release.
+
+## Folder structure
+
+```
+chen2026/
+├── README.md                        # this file
+├── environment.yaml                 # conda environment specification (Python 3.13 + all dependencies)
+├── convert_session.py               # main entry point — edit paths at the bottom and run
+├── chen2026nwbconverter.py          # NWBConverter subclass wiring all interfaces together
+├── interfaces/
+│   ├── raw_fiber_photometry_interface.py       # reads raw .abf; demultiplexes 470/405 nm streams
+└── metadata/
+    ├── general_metadata.yaml        # NWBFile and Subject fields shared across all sessions
+    └── fiber_photometry.yaml        # hardware metadata: devices, fiber implants, virus injections,
+                                     # indicators, FiberPhotometryTable rows, and response series entries
+```
+
+### Key files
+
+**`convert_session.py`** — the script you run to produce an NWB file. Edit the file paths and
+animal parameters in the `if __name__ == "__main__"` block at the bottom.
+
+**`metadata/general_metadata.yaml`** — contains static NWBFile fields shared across all sessions
+(`experiment_description`, `keywords`, `institution`, `lab`, `experimenter`) and Subject fields
+(`species`, `strain`, `age`, `sex`). Per-group session descriptions and subject descriptions are
+also stored here as templates; the `{genotype_label}` placeholder is filled in at runtime.
+
+**`metadata/fiber_photometry.yaml`** — contains all fiber photometry hardware metadata structured
+as `BaseFiberPhotometryInterface` expects: device models and instances (`DeviceModels`, `Devices`),
+virus and injection records (`FiberPhotometryViruses`, `FiberPhotometryVirusInjections`),
+fluorescence indicators (`FiberPhotometryIndicators`), the `FiberPhotometryTable` rows (one per
+fiber × excitation wavelength), and one response series entry per interface instance. Both groups
+are covered in a single file: Anxa-LRRK2 (DLS rows) and Calb-LRRK2 (DMS rows).
+
+**`interfaces/raw_fiber_photometry_interface.py`** — subclasses `BaseFiberPhotometryInterface`.
+Reads the multiplexed 520 nm PMT signal from an Axon `.abf` file and demultiplexes it into
+470 nm (functional) and 405 nm (isosbestic) streams using the `fxn_gen` LED-switching channel.
+Instantiated twice per session: once per wavelength.
+
+### Running the conversion
+
+You can run the conversion of a single session with the following command:
+
+```bash
+python src/dombeck_lab_to_nwb/chen2026/convert_session.py
+```

--- a/src/dombeck_lab_to_nwb/chen2026/__init__.py
+++ b/src/dombeck_lab_to_nwb/chen2026/__init__.py
@@ -1,0 +1,5 @@
+from .interfaces import Chen2026RawFiberPhotometryInterface
+
+__all__ = [
+    "Chen2026RawFiberPhotometryInterface",
+]

--- a/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
+++ b/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
@@ -1,0 +1,156 @@
+# Conversion Notes — Dombeck Lab NWB Conversions
+
+## LRRK2 Dataset (2026-07)
+
+**Manuscript:** "Leucine-rich repeat kinase 2 impairs the release sites of Parkinson's disease vulnerable dopamine axons", Chen, He et al. (in preparation)
+**Analysis code:** https://github.com/DombeckLab/lrrk2_photometry_analysis (Zenodo: 10.5281/zenodo.20244434)
+**Status:** Data inspection complete, metadata extracted from manuscript, code not yet written.
+**Detailed notes:** see `lrrk2_investigation.md`
+
+---
+
+### Experiment Summary
+
+In vivo fiber photometry of striatal dopamine release (GRAB-DA3m sensor) in awake head-fixed mice during optogenetic activation of dopamine neuron subtypes. Two groups:
+
+- **Calb-LRRK2**: Calb1-Cre mice, fiber in dorsal medial striatum (DMS), Calb1+ dopamine neurons
+- **Anxa-LRRK2**: Anxa1-iCre mice, fiber in dorsal lateral striatum (DLS), Anxa1+ dopamine neurons
+
+Each group has WT and LRRK2-G2019S knockin animals. Optogenetic stimulation of cell bodies in SNc via ChRmine (635 nm). No behavioral video — `camera` channel is a frame sync TTL only.
+
+---
+
+### Subject Groups
+
+| Group | Cre line | Genotypes | n | Recording site |
+|-------|----------|-----------|---|----------------|
+| Calb-LRRK2 | Calb1-Cre | WT, GS (LRRK2-G2019S, JAX:030961) | 12 | DMS |
+| Anxa-LRRK2 | Anxa1-iCre | WT, GS | 15 | DLS |
+
+- Background: C57BL/6J
+- Age at surgery: 6 months; recordings 4 weeks post-surgery
+- Sex: both male and female; no per-animal sex records confirmed yet
+
+---
+
+### Data Structure
+
+```
+/
+├── LRRK2-animal-list-meta.mat       # Animal metadata (ID, Genotype, Group, filename mapping)
+├── LRRK2_binning_and_processing.m   # MATLAB processing pipeline (Step 2)
+├── LRRK2_save_raw_data.m            # MATLAB processing pipeline (Step 1)
+├── Calb-LRRK2/
+│   ├── 2025_11_10_0002.abf          # Raw ABF files (one per animal)
+│   ├── ...                          # 12 total ABF files
+│   ├── 302/
+│   │   ├── 302raw.mat               # MATLAB intermediate (Step 1 — skip for NWB)
+│   │   └── 302_data.mat             # MATLAB processed (Step 2 — use for NWB)
+│   └── ...                          # 12 animals: 302, 306, 671, 673, 688, 740, 741, 848, 852, 935, 966, 1803
+└── Anxa-LRRK2/
+    ├── 2025_01_24_0002.abf          # 16 total ABF files (1 excluded by metadata)
+    ├── ...
+    ├── 3742/
+    │   ├── 3742raw.mat
+    │   └── 3742_data.mat
+    └── ...                          # 15 animals: 3742, 3743, 3947, 3948, 4004, 4005, 4007, 4253, 4398, 4401, 4558, 4561, 4651, 4652, 4885
+```
+
+**Total:** 27 animals (12 Calb + 15 Anxa), 1 session per animal.
+
+---
+
+### Raw ABF Channel Layout
+
+**6-channel** (Calb-LRRK2, closed-loop setup):
+`520sig`, `fxn_gen`, `initiation`, `opto_TTL`, `camera`, `treadmill`
+
+**5-channel** (Anxa-LRRK2, open-loop setup):
+`520sig`, `fxn_gen`, `opto_TTL`, `camera`, `treadmill`
+
+| Channel | Description | Signal type | Rate |
+|---------|-------------|-------------|------|
+| `520sig` | Multiplexed fluorescence — GCaMP/GRAB + isosbestic interleaved | Continuous analog | 2000 Hz |
+| `fxn_gen` | LED switching signal (>1V → 470 nm on, <1V → 405 nm on) | Square wave ~0–5V | 2000 Hz |
+| `initiation` | Closed-loop initiation trigger (Calb only) | Near-zero in inspected file | 2000 Hz |
+| `opto_TTL` | Optogenetic stimulation trigger (threshold >0.05V) | Sparse analog pulse | 2000 Hz |
+| `camera` | Camera frame trigger — sync only, no video recorded | Square wave 0/3.3V | 2000 Hz |
+| `treadmill` | Treadmill rotary encoder voltage | Continuous analog | 2000 Hz |
+
+`520sig` is demultiplexed using `fxn_gen`: samples where `fxn_gen > 1V` → 470 nm (GRAB signal); `fxn_gen < 1V` → 405 nm (isosbestic).
+
+---
+
+### Processed `_data.mat` Column Layout
+
+MATLAB table, one row per file. Read via h5py (`#subsystem#/MCOS`): column names at `MCOS[9]`, data at `MCOS[4]`.
+
+| Column | dtype | Rate | Description |
+|--------|-------|------|-------------|
+| `filename` | str | — | Corresponding ABF filename |
+| `corrected470` | float64 | 100 Hz | Baseline-corrected 470 nm signal |
+| `corrected405` | float64 | 100 Hz | Baseline-corrected 405 nm isosbestic |
+| `dff470` | float64 | 100 Hz | Smoothed ΔF/F 470 nm (moving mean 20 samples) |
+| `dff405` | float64 | 100 Hz | Smoothed ΔF/F 405 nm |
+| `TTL` | uint8 | 100 Hz | Binary opto TTL (0=off, 1=on), already binned |
+| `velocity` | float64 | 100 Hz | Treadmill velocity (m/s, calib factor 1.3532) |
+| `acceleration` | float64 | 100 Hz | Acceleration (m/s²) |
+| `camera` | float64 | 2000 Hz | Raw camera trigger — **not binned**, likely not needed in NWB |
+| `stim_sequence` | categorical | — | Opto stim sequence type: 'a' (18 animals) or 'b' (9 animals) — meaning unclear |
+
+Note: `stim_sequence` is a MATLAB categorical — pymatreader cannot parse it. Use h5py `MCOS[8]` (uint8), map 1→'a', 2→'b'.
+
+---
+
+### Key Hardware Metadata (from manuscript)
+
+| Component | Details |
+|-----------|---------|
+| Indicator | GRAB-DA3m (dopamine sensor, **not** GCaMP), pAAV-hSyn-GRAB-gDA3m, AAV1, Addgene #208698, ≥7×10¹² vg/mL |
+| Opsin | ChRmine, pAAV-Ef1a-DIO-ChRmine-mScarlet-WPRE, AAV5, Addgene #130998, 2.20×10¹³ vg/mL |
+| 470 nm LED | Thorlabs M70F3 |
+| 405 nm LED | Thorlabs M405FP1 |
+| LED power | 0.5 mW at fiber tip |
+| 470 nm excitation filter | Semrock FF02-472/30-25 |
+| 405 nm excitation filter | Semrock FF01-406/15-25 |
+| Excitation dichroic | Chroma T425lpxr |
+| Emission filter | Semrock FF01-540/50-25 |
+| Emission dichroic | Chroma T505lpxr |
+| Detector | Hamamatsu H10770PA-40 GaAsP PMT |
+| Amplifier | Stanford Research Systems SR570 |
+| DAQ | Axon Digidata 1550B, 2 kHz |
+| Photometry fiber (Anxa/DLS) | Doric MFC_200/250-0.66_2.0mm, 200 µm, 0.66 NA, 2 mm length/depth |
+| Photometry fiber (Calb/DMS) | Doric MFC_00/250-0.66_3.0mm, 200 µm, 0.66 NA, 3 mm length/depth |
+| Opto fiber (SNc, both groups) | Doric MFC_400/430-0.66_4.0mm, 400 µm, 0.66 NA, 4 mm length/depth |
+
+Fiber implant DV depth = ferrule length (Doric convention), referenced from dura surface.
+
+---
+
+### Comparison with Existing Pipelines
+
+#### vs `he_embargo_2024`
+
+**Reusable as-is:**
+- `AxonBinaryInterface` — same ABF format, 2000 Hz, same channel names
+- `AxonBinaryTimeSeriesInterface` — same channel mapping (`520sig` → Fluorescence, `treadmill` → Velocity)
+- `AxonBinaryTtlInterface` — same `fxn_gen` demux logic for 470/405 TTLs
+
+**Must adapt:**
+- Fiber photometry interface: MCOS indices differ (LRRK2: names at `[9]`, data at `[4]`; he_embargo_2024: `[7]`/`[2]`); single session per file (no `session_id` needed)
+- Optogenetics: TTL already binary at 100 Hz in `_data.mat` — no separate opto `.mat` file
+- New channels: `initiation` (Calb only), `stim_sequence` (session metadata)
+
+**ndx-fiber-photometry version:** use v0.2.x API (ndx-ophys-devices) — do **not** replicate the v0.1.0 approach used in he_embargo_2024 and azcorra2023.
+
+---
+
+### Open Questions (needs lab confirmation)
+
+1. **`stim_sequence` 'a' vs 'b'**: 18 animals have 'a', 9 have 'b', mixed across groups and genotypes. What does this distinguish?
+2. **`initiation` channel**: What does this signal represent? Store in NWB?
+3. **Per-animal sex records** — manuscript says both sexes used but no individual records confirmed
+4. **Photometry fiber DV coordinate for Calb group** — not stated in manuscript
+5. **GRAB-DA3m injection DV for Calb group** — not stated in manuscript
+6. **Publication DOI** — manuscript not yet published
+7. **Experimenter names** — confirm which authors collected the photometry data

--- a/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
+++ b/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
@@ -145,6 +145,25 @@ Fiber implant DV depth = ferrule length (Doric convention), referenced from dura
 
 ---
 
+### CommandedVoltageSeries — LED switching square wave
+
+The `fxn_gen` ABF channel records the function generator square wave that drives the two LEDs.
+It is stored as a `CommandedVoltageSeries` in `nwb.acquisition` and linked to both rows of the
+`FiberPhotometryTable` as the commanded voltage source.
+
+| Voltage level | Meaning | Demultiplexed stream |
+|---------------|---------|----------------------|
+| High (> 1 V) | 470 nm LED on | `FiberPhotometryResponseSeriesRawSignal` |
+| Low (< 1 V) | 405 nm LED on | `FiberPhotometryResponseSeriesIsosbesticControl` |
+
+- **Waveform frequency** (`frequency`): 100 Hz — the LED alternation rate (10 ms per cycle).
+- **Sampling rate** (`rate`): 2000 Hz — the ABF ADC rate at which the waveform is digitised.
+
+Transition samples at each LED switch edge are discarded before storing the demultiplexed
+fluorescence series, explaining why the raw signal timestamps are irregular.
+
+---
+
 ### Open Questions (needs lab confirmation)
 
 1. **`stim_sequence` 'a' vs 'b'**: 18 animals have 'a', 9 have 'b', mixed across groups and genotypes. What does this distinguish?

--- a/src/dombeck_lab_to_nwb/chen2026/convert_all_sessions.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_all_sessions.py
@@ -1,0 +1,131 @@
+"""Batch conversion of all Chen et al. 2026 (LRRK2) sessions to NWB.
+
+Edit DATA_DIR and NWB_OUTPUT_DIR at the top of this file, then run::
+
+    python src/dombeck_lab_to_nwb/chen2026/convert_all_sessions.py
+
+Sessions run in parallel (one process per CPU core by default).
+Failed sessions are logged individually and do not abort the batch.
+"""
+
+from __future__ import annotations
+
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from tqdm import tqdm
+
+from dombeck_lab_to_nwb.chen2026.convert_session import convert_session
+
+# ---------------------------------------------------------------------------
+# Configure paths here
+# ---------------------------------------------------------------------------
+DATA_DIR = Path("/Users/weian/lrrk2_data")
+NWB_OUTPUT_DIR = Path("/Users/weian/lrrk2_data/nwb-output")
+STUB_TEST = False
+MAX_WORKERS = 4  # number of parallel conversion processes
+# ---------------------------------------------------------------------------
+
+# Complete animal × session table derived from LRRK2-animal-list-meta.mat
+# and the filename column of each *_data.mat file.
+# Columns: animal_id, group, genotype, abf_filename
+SESSIONS = [
+    # Anxa-LRRK2 group (DLS, Anxa1-iCre)
+    {"animal_id": "3742", "group": "Anxa", "genotype": "GS", "abf_filename": "2025_01_24_0006.abf"},
+    {"animal_id": "3743", "group": "Anxa", "genotype": "GS", "abf_filename": "2025_01_24_0004.abf"},
+    {"animal_id": "3947", "group": "Anxa", "genotype": "WT", "abf_filename": "2025_01_27_0000.abf"},
+    {"animal_id": "3948", "group": "Anxa", "genotype": "WT", "abf_filename": "2025_01_27_0002.abf"},
+    {"animal_id": "4004", "group": "Anxa", "genotype": "GS", "abf_filename": "2025_08_13_0001.abf"},
+    {"animal_id": "4005", "group": "Anxa", "genotype": "GS", "abf_filename": "2025_08_13_0002.abf"},
+    {"animal_id": "4007", "group": "Anxa", "genotype": "GS", "abf_filename": "2025_08_13_0005.abf"},
+    {"animal_id": "4253", "group": "Anxa", "genotype": "WT", "abf_filename": "2025_08_14_0003.abf"},
+    {"animal_id": "4398", "group": "Anxa", "genotype": "WT", "abf_filename": "2025_05_02_0001.abf"},
+    {"animal_id": "4401", "group": "Anxa", "genotype": "WT", "abf_filename": "2025_07_02_0005.abf"},
+    {"animal_id": "4558", "group": "Anxa", "genotype": "WT", "abf_filename": "2025_05_20_0001.abf"},
+    {"animal_id": "4561", "group": "Anxa", "genotype": "WT", "abf_filename": "2025_07_02_0003.abf"},
+    {"animal_id": "4651", "group": "Anxa", "genotype": "GS", "abf_filename": "2025_07_02_0001.abf"},
+    {"animal_id": "4652", "group": "Anxa", "genotype": "GS", "abf_filename": "2025_05_20_0003.abf"},
+    {"animal_id": "4885", "group": "Anxa", "genotype": "GS", "abf_filename": "2025_01_24_0002.abf"},
+    # Calb-LRRK2 group (DMS, Calb1-Cre)
+    {"animal_id": "302", "group": "Calb", "genotype": "GS", "abf_filename": "2025_11_10_0005.abf"},
+    {"animal_id": "306", "group": "Calb", "genotype": "GS", "abf_filename": "2025_11_10_0009.abf"},
+    {"animal_id": "671", "group": "Calb", "genotype": "WT", "abf_filename": "2026_03_19_0000.abf"},
+    {"animal_id": "673", "group": "Calb", "genotype": "WT", "abf_filename": "2026_03_19_0004.abf"},
+    {"animal_id": "688", "group": "Calb", "genotype": "WT", "abf_filename": "2025_12_17_0007.abf"},
+    {"animal_id": "740", "group": "Calb", "genotype": "GS", "abf_filename": "2026_03_24_0003.abf"},
+    {"animal_id": "741", "group": "Calb", "genotype": "GS", "abf_filename": "2026_03_24_0004.abf"},
+    {"animal_id": "848", "group": "Calb", "genotype": "GS", "abf_filename": "2025_12_17_0006.abf"},
+    {"animal_id": "852", "group": "Calb", "genotype": "GS", "abf_filename": "2025_12_17_0003.abf"},
+    {"animal_id": "935", "group": "Calb", "genotype": "GS", "abf_filename": "2026_04_23_0004.abf"},
+    {"animal_id": "966", "group": "Calb", "genotype": "WT", "abf_filename": "2026_04_23_0003.abf"},
+    {"animal_id": "1803", "group": "Calb", "genotype": "WT", "abf_filename": "2025_11_10_0002.abf"},
+]
+
+
+def _session_to_nwb(session: dict, data_dir: Path, nwb_output_dir: Path, stub_test: bool) -> str:
+    """Convert one session; return a status string."""
+    animal_id = session["animal_id"]
+    group = session["group"]
+    genotype = session["genotype"]
+    group_dir = f"{group}-LRRK2"
+
+    abf_file = data_dir / group_dir / session["abf_filename"]
+
+    convert_session(
+        file_path=abf_file,
+        nwb_folder_path=nwb_output_dir,
+        subject_id=animal_id,
+        group=group,
+        genotype=genotype,
+        stub_test=stub_test,
+    )
+    return f"OK  {animal_id}"
+
+
+def _safe_session_to_nwb(session: dict, data_dir: Path, nwb_output_dir: Path, stub_test: bool) -> str:
+    """Wrapper that catches exceptions and writes an error log instead of crashing the pool."""
+    try:
+        return _session_to_nwb(session, data_dir, nwb_output_dir, stub_test)
+    except Exception:
+        animal_id = session["animal_id"]
+        error_path = nwb_output_dir / f"error_{animal_id}.txt"
+        error_path.parent.mkdir(parents=True, exist_ok=True)
+        error_path.write_text(f"Session: {session}\n\n{traceback.format_exc()}")
+        return f"ERR {animal_id} — see {error_path}"
+
+
+def dataset_to_nwb(
+    data_dir: Path = DATA_DIR,
+    nwb_output_dir: Path = NWB_OUTPUT_DIR,
+    stub_test: bool = STUB_TEST,
+    max_workers: int = MAX_WORKERS,
+) -> None:
+    nwb_output_dir.mkdir(parents=True, exist_ok=True)
+
+    futures = {}
+    with ProcessPoolExecutor(max_workers=max_workers) as pool:
+        for session in SESSIONS:
+            future = pool.submit(_safe_session_to_nwb, session, data_dir, nwb_output_dir, stub_test)
+            futures[future] = session["animal_id"]
+
+        results = []
+        with tqdm(total=len(futures), desc="Converting sessions", unit="session") as pbar:
+            for future in as_completed(futures):
+                status = future.result()
+                results.append(status)
+                pbar.update(1)
+                pbar.set_postfix_str(status)
+
+    print("\n--- Conversion summary ---")
+    errors = [r for r in results if r.startswith("ERR")]
+    ok = [r for r in results if r.startswith("OK")]
+    print(f"  Succeeded: {len(ok)} / {len(SESSIONS)}")
+    if errors:
+        print(f"  Failed ({len(errors)}):")
+        for e in errors:
+            print(f"    {e}")
+
+
+if __name__ == "__main__":
+    dataset_to_nwb()

--- a/src/dombeck_lab_to_nwb/chen2026/convert_session.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_session.py
@@ -1,0 +1,151 @@
+"""Convert a single Chen et al. 2026 session to NWB.
+
+Edit the paths and parameters in the ``if __name__ == "__main__"`` block at the
+bottom of this file, then run::
+
+    python convert_session.py
+"""
+
+from pathlib import Path
+from typing import Literal
+
+from neuroconv.utils import dict_deep_update, load_dict_from_file
+
+from dombeck_lab_to_nwb.chen2026.nwbconverter import Chen2026NWBConverter
+
+METADATA_DIR = Path(__file__).parent / "metadata"
+
+# Map group → (raw_signal_key, isosbestic_key, corrected_key, corrected_iso_key, dff_key, dff_iso_key)
+GROUP_TO_METADATA_KEYS = {
+    "Anxa": {
+        "RawSignal": "raw_signal_anxa",
+        "IsosbesticControl": "isosbestic_anxa",
+        # "CorrectedSignal": "corrected_signal_anxa",
+        # "CorrectedIsosbestic": "corrected_isosbestic_anxa",
+        # "DfOverF": "dff_anxa",
+        # "DfOverFIsosbestic": "dff_isosbestic_anxa",
+    },
+    "Calb": {
+        "RawSignal": "raw_signal_calb",
+        "IsosbesticControl": "isosbestic_calb",
+        # "CorrectedSignal": "corrected_signal_calb",
+        # "CorrectedIsosbestic": "corrected_isosbestic_calb",
+        # "DfOverF": "dff_calb",
+        # "DfOverFIsosbestic": "dff_isosbestic_calb",
+    },
+}
+
+GENOTYPE_LABELS = {
+    "WT": "LRRK2-WT",
+    "GS": "LRRK2-G2019S",
+}
+
+
+def convert_session(
+    file_path: str | Path,
+    nwb_folder_path: str | Path,
+    subject_id: str,
+    group: Literal["Anxa", "Calb"] = "Anxa",
+    genotype: Literal["WT", "GS"] = "WT",
+    stub_test: bool = False,
+) -> None:
+    """Convert one ABF recording to NWB.
+
+    Parameters
+    ----------
+    file_path : str | Path
+        Path to the raw .abf file.
+    nwb_folder_path : str | Path
+        Destination folder for the .nwb file.
+    subject_id : str
+        Animal identifier (e.g. "302").
+    group : Literal["Anxa", "Calb"], default "Anxa"
+        Experimental group: "Anxa" or "Calb".
+    genotype : Literal["WT", "GS"], default "WT"
+        Genotype: "WT" or "GS" (LRRK2-G2019S).
+    stub_test : bool
+        If True write only the first 100 samples (for CI / smoke tests).
+    """
+
+    metadata_keys = GROUP_TO_METADATA_KEYS[group]
+    genotype_label = GENOTYPE_LABELS[genotype]
+
+    nwb_folder_path = Path(nwb_folder_path)
+    if stub_test:
+        nwb_folder_path = nwb_folder_path / "stub"
+    nwb_folder_path.mkdir(parents=True, exist_ok=True)
+
+    # e.g. 2025-01-24-0002
+    session_id = Path(file_path).stem.replace("_", "-")
+    # e.g. 4007-anxa-wt
+    subject_id += f"-{group.lower()}-{genotype.lower()}"
+    nwbfile_path = nwb_folder_path / f"sub-{subject_id}_ses-{session_id}.nwb"
+
+    # Raw interfaces
+    source_data: dict = {
+        "RawSignal": {
+            "file_path": file_path,
+            "stream_names": ["470nm"],
+            "metadata_key": metadata_keys["RawSignal"],
+        },
+        "IsosbesticControl": {
+            "file_path": file_path,
+            "stream_names": ["405nm"],
+            "metadata_key": metadata_keys["IsosbesticControl"],
+        },
+    }
+
+    converter = Chen2026NWBConverter(source_data=source_data)
+    metadata = converter.get_metadata()
+
+    fp_metadata = load_dict_from_file(METADATA_DIR / "fiber_photometry.yaml")
+    metadata = dict_deep_update(metadata, fp_metadata)
+
+    # NWBFile: static fields from YAML + dynamic per-session fields
+    general_metadata = load_dict_from_file(METADATA_DIR / "general_metadata.yaml")
+    nwbfile_meta = general_metadata["NWBFile"].copy()
+    nwbfile_meta["session_description"] = general_metadata["SessionDescriptions"][group].format(
+        genotype_label=genotype_label
+    )
+    nwbfile_meta["session_id"] = session_id
+    metadata = dict_deep_update(metadata, {"NWBFile": nwbfile_meta})
+
+    # Subject: static fields from YAML + dynamic per-animal fields
+    subject_meta = general_metadata["Subject"].copy()
+    subject_meta["subject_id"] = subject_id
+    subject_meta["genotype"] = genotype_label
+    subject_meta["description"] = general_metadata["SubjectDescriptions"][group]
+    metadata["Subject"] = subject_meta
+
+    conversion_options: dict = {
+        "RawSignal": {"stub_test": stub_test},
+        "IsosbesticControl": {"stub_test": stub_test},
+    }
+
+    converter.run_conversion(
+        nwbfile_path=nwbfile_path,
+        metadata=metadata,
+        conversion_options=conversion_options,
+        overwrite=True,
+    )
+    print(f"Saved: {nwbfile_path}")
+
+
+if __name__ == "__main__":
+    # --- Edit these paths and parameters before running ---
+    abf_file = Path("/Users/weian/lrrk2_data/Anxa-LRRK2/2025_01_24_0002.abf")
+    output_path = Path("/Users/weian/lrrk2_data/nwb-output")
+    animal_id = "4007"
+    group = "Anxa"  # "Anxa" or "Calb"
+    genotype = "WT"  # "WT" or "GS"
+    stub_test = False
+    # ------------------------------------------------------
+
+    convert_session(
+        file_path=abf_file,
+        nwb_folder_path=output_path,
+        subject_id=animal_id,
+        group=group,
+        genotype=genotype,
+        stub_test=stub_test,
+    )

--- a/src/dombeck_lab_to_nwb/chen2026/environment.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/environment.yaml
@@ -1,0 +1,20 @@
+name: chen2026
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.13
+  - pip
+  - pip:
+    - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git
+    - ndx-fiber-photometry>=0.2.3
+    - ndx-ophys-devices>=0.3.1
+    - pynwb
+    - pyabf>=2.3.8
+    - pymatreader>=0.5.0
+    - h5py>=3.10.0
+    - nwbinspector>=0.4.35
+    - dandi>=0.65.0
+    - pyyaml>=6.0
+    - numpy>=1.26
+    - tqdm

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/__init__.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/__init__.py
@@ -1,0 +1,5 @@
+from .raw_fiber_photometry_interface import Chen2026RawFiberPhotometryInterface
+
+__all__ = [
+    "Chen2026RawFiberPhotometryInterface",
+]

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/raw_fiber_photometry_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/raw_fiber_photometry_interface.py
@@ -1,0 +1,144 @@
+"""Raw fiber photometry interface for Chen et al. 2026 (LRRK2 dataset).
+
+Reads the multiplexed fluorescence signal from an Axon Binary Format (.abf) file
+and exposes one demultiplexed stream — either 470 nm (functional) or 405 nm
+(isosbestic) — as a single-column FiberPhotometryResponseSeries.
+
+The 520sig channel contains both excitation wavelengths interleaved at 100 Hz.
+The fxn_gen channel (LED switching square wave) is used as a demultiplexing key:
+samples where fxn_gen > 1 V correspond to 470 nm excitation; samples where
+fxn_gen < 1 V correspond to 405 nm excitation. Transition samples at LED switch
+edges are discarded to avoid contamination.
+
+Instantiate once with stream_names=["470nm"] for the raw signal series and
+once with stream_names=["405nm"] for the isosbestic control series. Both
+instances that share the same file_path reuse a module-level demux cache so
+the ABF is only read once.
+"""
+
+from pathlib import Path
+
+import numpy as np
+from neuroconv.datainterfaces.fiber_photometry.basefiberphotometryinterface import (
+    BaseFiberPhotometryInterface,
+)
+
+# Module-level cache: file_path → {stream_name: (data, timestamps), "_datetime": abfDateTime}
+_DEMUX_CACHE: dict[str, dict] = {}
+
+
+def _load_and_demux(file_path: str, threshold_v: float = 1.0) -> dict:
+    """Read one ABF and return demuxed streams (cached by file_path)."""
+    if file_path in _DEMUX_CACHE:
+        return _DEMUX_CACHE[file_path]
+
+    import pyabf
+
+    abf = pyabf.ABF(file_path, loadData=True)
+    channel_names = [abf.adcNames[i].strip() for i in range(abf.channelCount)]
+
+    sig_idx = channel_names.index("520sig")
+    fxn_idx = channel_names.index("fxn_gen")
+
+    sig520 = abf.data[sig_idx]
+    fxn = abf.data[fxn_idx]
+
+    n = len(sig520)
+    timestamps = np.arange(n, dtype=np.float64) / abf.dataRate
+
+    # Mirror the MATLAB border-detection logic:
+    #   border405 = [0; abs(diff(wave405))]
+    #   border470 = [abs(diff(wave470)); 1]   ← last sample always a border
+    wave470 = fxn > threshold_v
+    wave405 = ~wave470
+
+    border405 = np.concatenate([[0], np.abs(np.diff(wave405.astype(np.float32)))])
+    border470 = np.concatenate([np.abs(np.diff(wave470.astype(np.float32))), [1]])
+    border = (border405 + border470) > 0
+
+    from zoneinfo import ZoneInfo
+
+    abf_dt = abf.abfDateTime
+    if abf_dt.tzinfo is None:
+        # ABF stores wall-clock time without timezone; lab is at Northwestern University (Chicago).
+        abf_dt = abf_dt.replace(tzinfo=ZoneInfo("America/Chicago"))
+
+    result = {
+        "470nm": (sig520[wave470 & ~border], timestamps[wave470 & ~border]),
+        "405nm": (sig520[wave405 & ~border], timestamps[wave405 & ~border]),
+        "_datetime": abf_dt,
+    }
+    _DEMUX_CACHE[file_path] = result
+    return result
+
+
+class Chen2026RawFiberPhotometryInterface(BaseFiberPhotometryInterface):
+    """Raw demultiplexed fiber photometry from ABF file (Chen et al. 2026).
+
+    Each instance writes one single-column FiberPhotometryResponseSeries.
+    Use stream_names=["470nm"] for the functional dopamine signal series
+    (FiberPhotometryResponseSeriesRawSignal) and stream_names=["405nm"] for
+    the isosbestic control series (FiberPhotometryResponseSeriesIsosbesticControl).
+
+    Pass metadata_key matching an entry in fiber_photometry.yaml:
+      "raw_signal_anxa" / "isosbestic_anxa"   — Anxa-LRRK2 animals (DLS)
+      "raw_signal_calb" / "isosbestic_calb"   — Calb-LRRK2 animals (DMS)
+    """
+
+    display_name = "Chen2026 Raw Fiber Photometry (ABF)"
+    associated_suffixes = (".abf",)
+    info = "Interface for raw demultiplexed fiber photometry from Axon Binary Format files."
+
+    STREAM_470 = "470nm"
+    STREAM_405 = "405nm"
+    FXN_THRESHOLD_V = 1.0
+
+    @classmethod
+    def get_available_streams(cls, file_path: str | Path) -> list[str]:
+        return [cls.STREAM_470, cls.STREAM_405]
+
+    def __init__(
+        self,
+        *,
+        file_path: str | Path,
+        stream_names: list[str],
+        metadata_key: str | None = None,
+        verbose: bool = False,
+    ):
+        """
+        Parameters
+        ----------
+        file_path : str | Path
+            Path to the .abf file.
+        stream_names : list of str
+            Which stream(s) to include. Pass ["470nm"] for the signal series or
+            ["405nm"] for the isosbestic control series.
+        metadata_key : str, optional
+            Key into metadata["FiberPhotometry"] for this series entry.
+            Must match an entry in fiber_photometry.yaml.
+        verbose : bool, default: False
+        """
+        super().__init__(
+            stream_names=stream_names,
+            metadata_key=metadata_key,
+            file_path=str(file_path),
+            verbose=verbose,
+        )
+
+    def _get_stream_data(self, *, stream_name: str) -> np.ndarray:
+        cache = _load_and_demux(self.source_data["file_path"], self.FXN_THRESHOLD_V)
+        return cache[stream_name][0]
+
+    def _get_stream_timestamps(self, *, stream_name: str) -> np.ndarray:
+        cache = _load_and_demux(self.source_data["file_path"], self.FXN_THRESHOLD_V)
+        return cache[stream_name][1]
+
+    def get_metadata(self) -> dict:
+        from neuroconv.utils import dict_deep_update
+
+        metadata = super().get_metadata()
+        cache = _load_and_demux(self.source_data["file_path"], self.FXN_THRESHOLD_V)
+        return dict_deep_update(
+            metadata,
+            {"NWBFile": {"session_start_time": cache["_datetime"]}},
+        )

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/raw_fiber_photometry_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/raw_fiber_photometry_interface.py
@@ -66,6 +66,7 @@ def _load_and_demux(file_path: str, threshold_v: float = 1.0) -> dict:
     result = {
         "470nm": (sig520[wave470 & ~border], timestamps[wave470 & ~border]),
         "405nm": (sig520[wave405 & ~border], timestamps[wave405 & ~border]),
+        "fxn_gen": (fxn, timestamps),
         "_datetime": abf_dt,
     }
     _DEMUX_CACHE[file_path] = result
@@ -95,7 +96,7 @@ class Chen2026RawFiberPhotometryInterface(BaseFiberPhotometryInterface):
 
     @classmethod
     def get_available_streams(cls, file_path: str | Path) -> list[str]:
-        return [cls.STREAM_470, cls.STREAM_405]
+        return [cls.STREAM_470, cls.STREAM_405, "fxn_gen"]
 
     def __init__(
         self,

--- a/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
@@ -237,6 +237,7 @@ FiberPhotometry:
         excitation_filter_metadata_key: ef_470
         emission_filter_metadata_key: emf
         dichroic_mirror_metadata_key: em_dichroic
+        commanded_voltage_series_metadata_key: fxn_gen
 
       dls_405:
         location: dorsal lateral striatum
@@ -249,6 +250,7 @@ FiberPhotometry:
         excitation_filter_metadata_key: ef_405
         emission_filter_metadata_key: emf
         dichroic_mirror_metadata_key: em_dichroic
+        commanded_voltage_series_metadata_key: fxn_gen
 
       # Calb-LRRK2 group — dorsal medial striatum (DMS)
       dms_470:
@@ -262,6 +264,7 @@ FiberPhotometry:
         excitation_filter_metadata_key: ef_470
         emission_filter_metadata_key: emf
         dichroic_mirror_metadata_key: em_dichroic
+        commanded_voltage_series_metadata_key: fxn_gen
 
       dms_405:
         location: dorsal medial striatum
@@ -274,6 +277,7 @@ FiberPhotometry:
         excitation_filter_metadata_key: ef_405
         emission_filter_metadata_key: emf
         dichroic_mirror_metadata_key: em_dichroic
+        commanded_voltage_series_metadata_key: fxn_gen
 
   # ---------------------------------------------------------------------------
   # Commanded voltage series — the LED switching square wave from the function

--- a/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
@@ -276,6 +276,22 @@ FiberPhotometry:
         dichroic_mirror_metadata_key: em_dichroic
 
   # ---------------------------------------------------------------------------
+  # Commanded voltage series — the LED switching square wave from the function
+  # generator. One series covers both excitation wavelengths (no need to split):
+  # high voltage (>1 V) = 470 nm LED on; low voltage (<1 V) = 405 nm LED on.
+  # ---------------------------------------------------------------------------
+  CommandedVoltageSeries:
+    fxn_gen:
+      name: CommandedVoltageSeries
+      description: >
+        LED switching square wave from the function generator at 2000 Hz.
+        High voltage (>1 V) marks 470 nm excitation periods; low voltage (<1 V) marks
+        405 nm isosbestic periods.
+      stream_name: fxn_gen
+      unit: V
+      frequency: 100.0
+
+  # ---------------------------------------------------------------------------
   # Response series entries — one per interface instance (one stream each).
   # The converter passes metadata_key matching one of these keys to the interface.
   # ---------------------------------------------------------------------------

--- a/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
@@ -17,23 +17,12 @@
 
 DeviceModels:
 
-  ofm_dls:
+  ofm_photometry:
     type: OpticalFiberModel
-    name: optical_fiber_model_dls
-    description: "Doric Lenses fiber cannula used in Anxa-LRRK2 group (DLS). Ferrule length 2 mm = implant tip depth from dura surface."
+    name: optical_fiber_model
+    description: "Doric Lenses fiber cannula (MFC series, ZF1.25(G) ferrule) used for fiber photometry in both experimental groups. Shared model; ferrule length varies by implant site: 2 mm for Anxa-LRRK2 (DLS) and 3 mm for Calb-LRRK2 (DMS); tip depth from dura surface recorded per-fiber in the FiberPhotometryTable."
     manufacturer: Doric Lenses
-    model_number: MFC_200/250-0.66_2.0mm_ZF1.25(G)_FLT
-    numerical_aperture: 0.66
-    core_diameter_in_um: 200.0
-    ferrule_model: ZF1.25(G)
-    ferrule_diameter_in_mm: 1.25
-
-  ofm_dms:
-    type: OpticalFiberModel
-    name: optical_fiber_model_dms
-    description: "Doric Lenses fiber cannula used in Calb-LRRK2 group (DMS). Ferrule length 3 mm = implant tip depth from dura surface."
-    manufacturer: Doric Lenses
-    model_number: MFC_200/250-0.66_3.0mm_ZF1.25(G)_FLT
+    model_number: MFC_200/250-0.66_ZF1.25(G)_FLT
     numerical_aperture: 0.66
     core_diameter_in_um: 200.0
     ferrule_model: ZF1.25(G)
@@ -115,7 +104,7 @@ Devices:
     type: OpticalFiber
     name: optical_fiber_dls
     description: "Photometry fiber implanted in dorsal lateral striatum (DLS), right hemisphere. Ferrule length 2 mm = tip depth from dura surface."
-    device_model_metadata_key: ofm_dls
+    device_model_metadata_key: ofm_photometry
     fiber_insertion:
       depth_in_mm: 2.0
       insertion_position_ap_in_mm: 0.50
@@ -128,7 +117,7 @@ Devices:
     type: OpticalFiber
     name: optical_fiber_dms
     description: "Photometry fiber implanted in dorsal medial striatum (DMS), right hemisphere. Ferrule length 3 mm = tip depth from dura surface."
-    device_model_metadata_key: ofm_dms
+    device_model_metadata_key: ofm_photometry
     fiber_insertion:
       depth_in_mm: 3.0
       insertion_position_ap_in_mm: 0.50

--- a/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
@@ -1,0 +1,430 @@
+# Fiber photometry metadata for Chen et al. 2026 (LRRK2 dataset)
+#
+# Shared hardware metadata for all 27 animals. Both experimental groups are
+# covered here (Anxa-LRRK2 → DLS rows; Calb-LRRK2 → DMS rows). The
+# converter selects the appropriate FiberPhotometryTable rows and response
+# series entry for each animal based on its group.
+#
+# Coordinates: AP and ML from Bregma at the cortical surface (Paxinos atlas).
+# DV from the dura surface. Fiber tip depth = ferrule length (Doric convention).
+# All implants in the right hemisphere.
+#
+# Reference: Chen, He et al. (in preparation).
+
+# ---------------------------------------------------------------------------
+# Device models — hardware specifications, one entry per model variant.
+# ---------------------------------------------------------------------------
+
+DeviceModels:
+
+  ofm_dls:
+    type: OpticalFiberModel
+    name: optical_fiber_model_dls
+    description: "Doric Lenses fiber cannula used in Anxa-LRRK2 group (DLS). Ferrule length 2 mm = implant tip depth from dura surface."
+    manufacturer: Doric Lenses
+    model_number: MFC_200/250-0.66_2.0mm_ZF1.25(G)_FLT
+    numerical_aperture: 0.66
+    core_diameter_in_um: 200.0
+    ferrule_model: ZF1.25(G)
+    ferrule_diameter_in_mm: 1.25
+
+  ofm_dms:
+    type: OpticalFiberModel
+    name: optical_fiber_model_dms
+    description: "Doric Lenses fiber cannula used in Calb-LRRK2 group (DMS). Ferrule length 3 mm = implant tip depth from dura surface."
+    manufacturer: Doric Lenses
+    model_number: MFC_200/250-0.66_3.0mm_ZF1.25(G)_FLT
+    numerical_aperture: 0.66
+    core_diameter_in_um: 200.0
+    ferrule_model: ZF1.25(G)
+    ferrule_diameter_in_mm: 1.25
+
+  esm_470:
+    type: ExcitationSourceModel
+    name: thorlabs_signal_led_model
+    description: "Thorlabs M470F3 470 nm fiber-coupled LED for GRAB-DA3m functional excitation."
+    manufacturer: Thorlabs
+    model_number: M470F3
+    source_type: LED
+    excitation_mode: one-photon
+    wavelength_range_in_nm: [460.0, 480.0]  # peak 470 nm, FWHM ~20 nm
+
+  esm_405:
+    type: ExcitationSourceModel
+    name: thorlabs_isosbestic_led_model
+    description: "Thorlabs M405FP1 405 nm fiber-coupled LED for isosbestic control (motion artifact correction)."
+    manufacturer: Thorlabs
+    model_number: M405FP1
+    source_type: LED
+    excitation_mode: one-photon
+    wavelength_range_in_nm: [399.0, 411.0]  # peak 405 nm, FWHM ~12 nm
+
+  pdm:
+    type: PhotodetectorModel
+    name: photodetector_model
+    description: "Hamamatsu H10770PA-40 GaAsP PMT photosensor module for green fluorescence detection."
+    manufacturer: Hamamatsu
+    model_number: H10770PA-40
+    detector_type: PMT
+    wavelength_range_in_nm: [300.0, 740.0]  # GaAsP photocathode spectral response range
+    # TODO: confirm gain value from datasheet (PMT module; typical GaAsP gain ~1e6)
+    # gain: 1000000.0
+    # gain_unit: A/A
+
+  bofm_470:
+    type: BandOpticalFilterModel
+    name: signal_excitation_filter_model
+    description: "Semrock FF02-472/30-25 bandpass filter for 470 nm excitation path."
+    manufacturer: Semrock
+    center_wavelength_in_nm: 472.0
+    bandwidth_in_nm: 30.0
+    filter_type: Bandpass
+
+  bofm_405:
+    type: BandOpticalFilterModel
+    name: isosbestic_excitation_filter_model
+    description: "Semrock FF01-406/15-25 bandpass filter for 405 nm excitation path."
+    manufacturer: Semrock
+    center_wavelength_in_nm: 406.0
+    bandwidth_in_nm: 15.0
+    filter_type: Bandpass
+
+  bofm_em:
+    type: BandOpticalFilterModel
+    name: emission_filter_model
+    description: "Semrock FF01-540/50-25 bandpass emission filter for green fluorescence."
+    manufacturer: Semrock
+    center_wavelength_in_nm: 540.0
+    bandwidth_in_nm: 50.0
+    filter_type: Bandpass
+
+  dmm_em:
+    type: DichroicMirrorModel
+    name: emission_dichroic_model
+    description: "Chroma Technology T505lpxr long-pass dichroic mirror (cut-on 505 nm) separating green emission from excitation light."
+    manufacturer: Chroma Technology
+    cut_on_wavelength_in_nm: 505.0
+
+# ---------------------------------------------------------------------------
+# Device instances — one per physical device used in the setup.
+# ---------------------------------------------------------------------------
+
+Devices:
+
+  fiber_dls:
+    type: OpticalFiber
+    name: optical_fiber_dls
+    description: "Photometry fiber implanted in dorsal lateral striatum (DLS), right hemisphere. Ferrule length 2 mm = tip depth from dura surface."
+    device_model_metadata_key: ofm_dls
+    fiber_insertion:
+      depth_in_mm: 2.0
+      insertion_position_ap_in_mm: 0.50
+      insertion_position_ml_in_mm: 1.80
+      insertion_position_dv_in_mm: 2.0
+      hemisphere: right
+      position_reference: "Bregma at cortical surface (AP/ML); dura surface (DV)"
+
+  fiber_dms:
+    type: OpticalFiber
+    name: optical_fiber_dms
+    description: "Photometry fiber implanted in dorsal medial striatum (DMS), right hemisphere. Ferrule length 3 mm = tip depth from dura surface."
+    device_model_metadata_key: ofm_dms
+    fiber_insertion:
+      depth_in_mm: 3.0
+      insertion_position_ap_in_mm: 0.50
+      insertion_position_ml_in_mm: 1.40
+      insertion_position_dv_in_mm: 3.0
+      hemisphere: right
+      position_reference: "Bregma at cortical surface (AP/ML); dura surface (DV)"
+
+  es_470:
+    type: ExcitationSource
+    name: signal_excitation_source
+    description: "470 nm LED (GRAB-DA3m functional excitation). Power: 0.5 mW at fiber cannula tip. Alternated with 405 nm LED at 100 Hz via waveform generator."
+    device_model_metadata_key: esm_470
+    power_in_W: 0.0005
+
+  es_405:
+    type: ExcitationSource
+    name: isosbestic_excitation_source
+    description: "405 nm LED (isosbestic control for motion artifact correction). Power: 0.5 mW at fiber cannula tip. Alternated with 470 nm LED at 100 Hz."
+    device_model_metadata_key: esm_405
+    power_in_W: 0.0005
+
+  pd:
+    type: Photodetector
+    name: photodetector
+    description: "GaAsP PMT (Hamamatsu H10770PA-40) for green fluorescence detection. Signal amplified with Stanford Research Systems SR570 preamplifier."
+    device_model_metadata_key: pdm
+
+  ef_470:
+    type: BandOpticalFilter
+    name: signal_excitation_filter
+    description: "Bandpass filter for 470 nm LED excitation path (Semrock FF02-472/30-25)."
+    device_model_metadata_key: bofm_470
+
+  ef_405:
+    type: BandOpticalFilter
+    name: isosbestic_excitation_filter
+    description: "Bandpass filter for 405 nm LED excitation path (Semrock FF01-406/15-25)."
+    device_model_metadata_key: bofm_405
+
+  emf:
+    type: BandOpticalFilter
+    name: emission_filter
+    description: "Bandpass emission filter for green fluorescence (Semrock FF01-540/50-25)."
+    device_model_metadata_key: bofm_em
+
+  em_dichroic:
+    type: DichroicMirror
+    name: emission_dichroic_mirror
+    description: "Emission dichroic mirror (Chroma T505lpxr) separating green fluorescence from 405/470 nm excitation light before the PMT."
+    device_model_metadata_key: dmm_em
+
+# ---------------------------------------------------------------------------
+# FiberPhotometry block — indicators, viruses, injections, table, and series.
+# ---------------------------------------------------------------------------
+
+FiberPhotometry:
+
+  FiberPhotometryViruses:
+    grab_da3m_aav:
+      name: GRAB_DA3m_AAV1
+      construct_name: pAAV-hSyn-GRAB-gDA3m
+      manufacturer: Addgene
+      titer_in_vg_per_ml: 7000000000000.0
+      description: "AAV1 serotype. Addgene catalog #208698. Titer ≥ 7×10¹² vg/mL. Diluted 1:2 in PBS before injection (0.1 µL per site)."
+
+  FiberPhotometryVirusInjections:
+    inj_grab_dls:
+      name: GRAB_DA3m_injection_DLS
+      location: dorsal lateral striatum
+      hemisphere: right
+      ap_in_mm: 0.50
+      ml_in_mm: 1.80
+      dv_in_mm: 1.90
+      volume_in_uL: 0.10
+      reference: "Bregma at cortical surface (AP/ML); dura surface (DV)"
+      viral_vector_metadata_key: grab_da3m_aav
+
+    inj_grab_dms:
+      name: GRAB_DA3m_injection_DMS
+      location: dorsal medial striatum
+      hemisphere: right
+      ap_in_mm: 0.50
+      ml_in_mm: 1.40
+      # TODO: DV not stated in manuscript; using estimate (0.1 mm shallower than fiber tip). Confirm with lab.
+      dv_in_mm: 2.9
+      volume_in_uL: 0.10
+      reference: "Bregma at cortical surface (AP/ML); dura surface (DV)"
+      viral_vector_metadata_key: grab_da3m_aav
+
+  FiberPhotometryIndicators:
+    grab_da3m_dls:
+      name: GRAB_DA3m_DLS
+      label: GRAB-DA3m
+      description: "GPCR-based dopamine fluorescent sensor (dopamine indicator). Excitation at 470 nm (functional) and 405 nm (isosbestic control); emission ~520 nm. Injected into dorsal lateral striatum (Anxa-LRRK2 group)."
+      viral_vector_injection_metadata_key: inj_grab_dls
+
+    grab_da3m_dms:
+      name: GRAB_DA3m_DMS
+      label: GRAB-DA3m
+      description: "GPCR-based dopamine fluorescent sensor (dopamine indicator). Excitation at 470 nm (functional) and 405 nm (isosbestic control); emission ~520 nm. Injected into dorsal medial striatum (Calb-LRRK2 group)."
+      viral_vector_injection_metadata_key: inj_grab_dms
+
+  FiberPhotometryTable:
+    name: fiber_photometry_table
+    description: "Fiber photometry recording setup. Each row = one optical fiber × one excitation wavelength. Two groups: Anxa-LRRK2 (DLS rows) and Calb-LRRK2 (DMS rows)."
+    rows:
+      # Anxa-LRRK2 group — dorsal lateral striatum (DLS)
+      dls_470:
+        location: dorsal lateral striatum
+        excitation_wavelength_in_nm: 470.0
+        emission_wavelength_in_nm: 520.0
+        indicator_metadata_key: grab_da3m_dls
+        optical_fiber_metadata_key: fiber_dls
+        excitation_source_metadata_key: es_470
+        photodetector_metadata_key: pd
+        excitation_filter_metadata_key: ef_470
+        emission_filter_metadata_key: emf
+        dichroic_mirror_metadata_key: em_dichroic
+
+      dls_405:
+        location: dorsal lateral striatum
+        excitation_wavelength_in_nm: 405.0
+        emission_wavelength_in_nm: 520.0
+        indicator_metadata_key: grab_da3m_dls
+        optical_fiber_metadata_key: fiber_dls
+        excitation_source_metadata_key: es_405
+        photodetector_metadata_key: pd
+        excitation_filter_metadata_key: ef_405
+        emission_filter_metadata_key: emf
+        dichroic_mirror_metadata_key: em_dichroic
+
+      # Calb-LRRK2 group — dorsal medial striatum (DMS)
+      dms_470:
+        location: dorsal medial striatum
+        excitation_wavelength_in_nm: 470.0
+        emission_wavelength_in_nm: 520.0
+        indicator_metadata_key: grab_da3m_dms
+        optical_fiber_metadata_key: fiber_dms
+        excitation_source_metadata_key: es_470
+        photodetector_metadata_key: pd
+        excitation_filter_metadata_key: ef_470
+        emission_filter_metadata_key: emf
+        dichroic_mirror_metadata_key: em_dichroic
+
+      dms_405:
+        location: dorsal medial striatum
+        excitation_wavelength_in_nm: 405.0
+        emission_wavelength_in_nm: 520.0
+        indicator_metadata_key: grab_da3m_dms
+        optical_fiber_metadata_key: fiber_dms
+        excitation_source_metadata_key: es_405
+        photodetector_metadata_key: pd
+        excitation_filter_metadata_key: ef_405
+        emission_filter_metadata_key: emf
+        dichroic_mirror_metadata_key: em_dichroic
+
+  # ---------------------------------------------------------------------------
+  # Response series entries — one per interface instance (one stream each).
+  # The converter passes metadata_key matching one of these keys to the interface.
+  # ---------------------------------------------------------------------------
+
+  # Anxa-LRRK2 group (DLS) — 470 nm functional signal
+  raw_signal_anxa:
+    name: FiberPhotometryResponseSeriesRawSignal
+    description: >
+      Raw demultiplexed GRAB-DA3m fluorescence from ABF recording (Anxa-LRRK2 group, DLS),
+      470 nm excitation (functional dopamine signal).
+      Recorded at 2 kHz; timestamps are irregular (transition samples between LED cycles discarded).
+      LED alternation at 100 Hz via waveform generator.
+    fiber_photometry_table_region:
+      - dls_470
+    fiber_photometry_table_region_description: "DLS 470 nm functional channel."
+
+  # Anxa-LRRK2 group (DLS) — 405 nm isosbestic control
+  isosbestic_anxa:
+    name: FiberPhotometryResponseSeriesIsosbesticControl
+    description: >
+      Raw demultiplexed GRAB-DA3m isosbestic fluorescence from ABF recording (Anxa-LRRK2 group, DLS),
+      405 nm excitation (isosbestic control for motion artifact correction).
+      Recorded at 2 kHz; timestamps are irregular (transition samples between LED cycles discarded).
+      LED alternation at 100 Hz via waveform generator.
+    fiber_photometry_table_region:
+      - dls_405
+    fiber_photometry_table_region_description: "DLS 405 nm isosbestic control channel."
+
+  # Calb-LRRK2 group (DMS) — 470 nm functional signal
+  raw_signal_calb:
+    name: FiberPhotometryResponseSeriesRawSignal
+    description: >
+      Raw demultiplexed GRAB-DA3m fluorescence from ABF recording (Calb-LRRK2 group, DMS),
+      470 nm excitation (functional dopamine signal).
+      Recorded at 2 kHz; timestamps are irregular (transition samples between LED cycles discarded).
+      LED alternation at 100 Hz via waveform generator.
+    fiber_photometry_table_region:
+      - dms_470
+    fiber_photometry_table_region_description: "DMS 470 nm functional channel."
+
+  # Calb-LRRK2 group (DMS) — 405 nm isosbestic control
+  isosbestic_calb:
+    name: FiberPhotometryResponseSeriesIsosbesticControl
+    description: >
+      Raw demultiplexed GRAB-DA3m isosbestic fluorescence from ABF recording (Calb-LRRK2 group, DMS),
+      405 nm excitation (isosbestic control for motion artifact correction).
+      Recorded at 2 kHz; timestamps are irregular (transition samples between LED cycles discarded).
+      LED alternation at 100 Hz via waveform generator.
+    fiber_photometry_table_region:
+      - dms_405
+    fiber_photometry_table_region_description: "DMS 405 nm isosbestic control channel."
+#
+#  # ---------------------------------------------------------------------------
+#  # Processed response series — from *_data.mat (100 Hz, camera-trigger-aligned).
+#  # baselineCorrect: sliding-window 8th-percentile subtract-then-divide (window=2001).
+#  # df_f: (corrected - F0) / F0 * 100, F0 = 8th percentile; smoothed with 20-sample moving mean.
+#  # ---------------------------------------------------------------------------
+#
+#  # Anxa-LRRK2 group (DLS) — baseline-corrected 470 nm
+#  corrected_signal_anxa:
+#    name: FiberPhotometryResponseSeriesCorrectedSignal
+#    description: >
+#      Baseline-corrected GRAB-DA3m 470 nm fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
+#      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
+#      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
+#    fiber_photometry_table_region:
+#      - dls_470
+#    fiber_photometry_table_region_description: "DLS 470 nm functional channel (baseline-corrected)."
+#
+#  # Anxa-LRRK2 group (DLS) — baseline-corrected 405 nm isosbestic
+#  corrected_isosbestic_anxa:
+#    name: FiberPhotometryResponseSeriesCorrectedIsosbesticControl
+#    description: >
+#      Baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
+#      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
+#      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
+#    fiber_photometry_table_region:
+#      - dls_405
+#    fiber_photometry_table_region_description: "DLS 405 nm isosbestic control channel (baseline-corrected)."
+#
+#  # Anxa-LRRK2 group (DLS) — ΔF/F 470 nm
+#  dff_anxa:
+#    name: FiberPhotometryResponseSeriesDfOverF
+#    description: >
+#      % ΔF/F of baseline-corrected GRAB-DA3m 470 nm fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
+#      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
+#    fiber_photometry_table_region:
+#      - dls_470
+#    fiber_photometry_table_region_description: "DLS 470 nm functional channel (% ΔF/F, smoothed)."
+#
+#  # Anxa-LRRK2 group (DLS) — ΔF/F 405 nm isosbestic
+#  dff_isosbestic_anxa:
+#    name: FiberPhotometryResponseSeriesDfOverFIsosbesticControl
+#    description: >
+#      % ΔF/F of baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
+#      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
+#    fiber_photometry_table_region:
+#      - dls_405
+#    fiber_photometry_table_region_description: "DLS 405 nm isosbestic control channel (% ΔF/F, smoothed)."
+#
+#  # Calb-LRRK2 group (DMS) — baseline-corrected 470 nm
+#  corrected_signal_calb:
+#    name: FiberPhotometryResponseSeriesCorrectedSignal
+#    description: >
+#      Baseline-corrected GRAB-DA3m 470 nm fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
+#      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
+#      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
+#    fiber_photometry_table_region:
+#      - dms_470
+#    fiber_photometry_table_region_description: "DMS 470 nm functional channel (baseline-corrected)."
+#
+#  # Calb-LRRK2 group (DMS) — baseline-corrected 405 nm isosbestic
+#  corrected_isosbestic_calb:
+#    name: FiberPhotometryResponseSeriesCorrectedIsosbesticControl
+#    description: >
+#      Baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
+#      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
+#      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
+#    fiber_photometry_table_region:
+#      - dms_405
+#    fiber_photometry_table_region_description: "DMS 405 nm isosbestic control channel (baseline-corrected)."
+#
+#  # Calb-LRRK2 group (DMS) — ΔF/F 470 nm
+#  dff_calb:
+#    name: FiberPhotometryResponseSeriesDfOverF
+#    description: >
+#      % ΔF/F of baseline-corrected GRAB-DA3m 470 nm fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
+#      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
+#    fiber_photometry_table_region:
+#      - dms_470
+#    fiber_photometry_table_region_description: "DMS 470 nm functional channel (% ΔF/F, smoothed)."
+#
+#  # Calb-LRRK2 group (DMS) — ΔF/F 405 nm isosbestic
+#  dff_isosbestic_calb:
+#    name: FiberPhotometryResponseSeriesDfOverFIsosbesticControl
+#    description: >
+#      % ΔF/F of baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
+#      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
+#    fiber_photometry_table_region:
+#      - dms_405
+#    fiber_photometry_table_region_description: "DMS 405 nm isosbestic control channel (% ΔF/F, smoothed)."

--- a/src/dombeck_lab_to_nwb/chen2026/metadata/general_metadata.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/metadata/general_metadata.yaml
@@ -1,0 +1,73 @@
+# General NWB metadata for Chen et al. 2026 (LRRK2 fiber photometry dataset).
+# Static fields shared across all sessions. Dynamic per-animal fields
+# (session_start_time, Subject.subject_id, Subject.genotype)
+# are filled in by convert_session.py at runtime.
+
+NWBFile:
+  #  related_publications:
+  #    - https://doi.org/... # The publication DOI can be added here
+  experiment_description: >
+    In vivo fiber photometry of striatal dopamine release in awake, head-fixed mice expressing
+    the dopamine sensor GRAB-DA3m. Two intersectional mouse lines targeting distinct dopamine
+    neuron subtypes were studied: Anxa1-iCre mice (Anxa1+, vulnerable subtype) with fiber
+    photometry in the dorsal lateral striatum (DLS), and Calb1-Cre mice (Calb1+, resilient
+    subtype) with fiber photometry in the dorsal medial striatum (DMS). Optogenetic activation
+    of subtype-specific dopamine neuron cell bodies in SNc was achieved via Cre-dependent
+    ChRmine expression and red-light (635 nm) stimulation. LRRK2-WT and LRRK2-G2019S knockin
+    mice were compared to investigate how pathogenic LRRK2 kinase activity affects dopamine
+    synaptic function in a subtype-specific manner.
+  keywords:
+    - fiber photometry
+    - dopamine
+    - GRAB-DA
+    - optogenetics
+    - ChRmine
+    - Parkinson's disease
+    - substantia nigra
+    - striatum
+    - dopamine neuron subtypes
+    - mouse
+    - treadmill locomotion
+    - head-fixed
+  institution: Northwestern University
+  lab: Dombeck Lab
+  experimenter:
+    - He, Elena
+
+# Per-group session descriptions. The placeholder {genotype_label} is substituted
+# at runtime with either "LRRK2-WT" or "LRRK2-G2019S".
+SessionDescriptions:
+  Anxa: >
+    Fiber photometry recording of GRAB-DA3m dopamine fluorescence in the dorsal lateral
+    striatum (DLS) during optogenetic activation of Anxa1+ dopamine neuron cell bodies in
+    SNc (ChRmine, 635 nm) in an awake head-fixed {genotype_label} mouse on a treadmill.
+    Data sources: fiber photometry (raw multiplexed fluorescence at 2 kHz),
+    optogenetic stimulation TTL, and treadmill velocity.
+  Calb: >
+    Fiber photometry recording of GRAB-DA3m dopamine fluorescence in the dorsal medial
+    striatum (DMS) during optogenetic activation of Calb1+ dopamine neuron cell bodies in
+    SNc (ChRmine, 635 nm) in an awake head-fixed {genotype_label} mouse on a treadmill.
+    Data sources: fiber photometry (raw multiplexed fluorescence at 2 kHz),
+    optogenetic stimulation TTL, and treadmill velocity.
+
+Subject:
+  species: Mus musculus
+  strain: C57BL/6J
+  # Approximate age: surgeries at ~6 months; recordings ~4 weeks post-surgery.
+  age: P210D
+  # TODO: confirm per-animal sex with lab; using "U" (unknown) until records are provided.
+  sex: U
+  # genotype is set per-animal at runtime ("LRRK2-WT" or "LRRK2-G2019S")
+
+# Per-group subject descriptions (set as Subject.description in the NWB file).
+SubjectDescriptions:
+  Anxa: >
+    Anxa1-iCre mouse on a C57BL/6J background expressing the GRAB-DA3m dopamine sensor in the
+    dorsal lateral striatum (DLS) via unilateral AAV1-hSyn injection. Anxa1+ dopaminergic neurons
+    represent a vulnerability-associated subtype studied in the context of LRRK2-linked
+    Parkinson's disease pathology.
+  Calb: >
+    Calb1-Cre mouse on a C57BL/6J background expressing the GRAB-DA3m dopamine sensor in the
+    dorsal medial striatum (DMS) via unilateral AAV1-hSyn injection. Calb1+ dopaminergic neurons
+    represent a resilience-associated subtype studied in the context of LRRK2-linked
+    Parkinson's disease pathology.

--- a/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
+++ b/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
@@ -1,0 +1,19 @@
+from neuroconv import NWBConverter
+
+from .interfaces import Chen2026RawFiberPhotometryInterface
+
+
+class Chen2026NWBConverter(NWBConverter):
+    """
+    NWB converter for Chen et al. 2026 (LRRK2 fiber photometry dataset).
+
+    Raw interfaces (always present):
+      RawSignal          — 470 nm demultiplexed from ABF
+      IsosbesticControl  — 405 nm demultiplexed from ABF
+
+    """
+
+    data_interface_classes = dict(
+        RawSignal=Chen2026RawFiberPhotometryInterface,
+        IsosbesticControl=Chen2026RawFiberPhotometryInterface,
+    )

--- a/src/dombeck_lab_to_nwb/chen2026/project_track.md
+++ b/src/dombeck_lab_to_nwb/chen2026/project_track.md
@@ -22,9 +22,9 @@
 - [x] Processed fiber photometry interface (`processed_fiber_photometry_interface.py`) — reads `*_data.mat` (MATLAB v7.3 HDF5 via h5py reference chain); exposes corrected470, corrected405, dff470, dff405 at 100 Hz
 - [x] `Chen2026NWBConverter` — RawSignal + IsosbesticControl interfaces wired
 - [x] Stub test passes — Anxa group, animal 4007, session 2025-01-24-0002 ✓
-- [ ] Stub test — Calb group (need to download a Calb ABF)
-- [ ] ABF → animal ID mapping from `LRRK2-animal-list-meta.mat` (which ABF file corresponds to which animal?)
-- [ ] `convert_all_sessions.py` — batch script for all 27 animals
+- [x] Stub test — Calb group (need to download a Calb ABF)
+- [x] ABF → animal ID mapping from `LRRK2-animal-list-meta.mat` (which ABF file corresponds to which animal?)
+- [x] `convert_all_sessions.py` — batch script for all 27 animals
 - [ ] **Pending lab reply** — per-animal sex records, `stim_sequence` 'a' vs 'b' meaning, `initiation` channel meaning (Calb only), Calb DV fiber coordinate, Calb injection DV coordinate, publication DOI, experimenter name(s)
 
 ---
@@ -47,8 +47,8 @@ Genotypes per group: WT and LRRK2-G2019S (JAX:030961). Background: C57BL/6J. Age
 - [x] `FiberPhotometryResponseSeriesRawSignal` — 470 nm functional channel (GRAB-DA3m)
 - [x] `FiberPhotometryResponseSeriesIsosbesticControl` — 405 nm isosbestic control
 - [x] Interfaces implemented and stub tested (Anxa group)
-- [ ] Enable for Calb group (stub test)
-- [ ] Wire into `convert_all_sessions.py`
+- [x] Enable for Calb group (stub test)
+- [x] Wire into `convert_all_sessions.py`
 
 #### Processed fluorescence (from `*_data.mat` — 100 Hz, regular timestamps)
 

--- a/src/dombeck_lab_to_nwb/chen2026/project_track.md
+++ b/src/dombeck_lab_to_nwb/chen2026/project_track.md
@@ -1,0 +1,106 @@
+# Dombeck Lab — Chen et al. 2026 (LRRK2) Conversion Progress
+
+**Manuscript:** "Leucine-rich repeat kinase 2 impairs the release sites of Parkinson's disease vulnerable dopamine axons", Chen, He et al. (in preparation)
+**Analysis code:** https://github.com/DombeckLab/lrrk2_photometry_analysis (Zenodo: 10.5281/zenodo.20244434)
+**Google Drive data:** https://drive.google.com/drive/u/0/folders/1Tw_es0etUGW8ttCysiUQYRJGnU0qeh3Q
+**Conversion folder:** `src/dombeck_lab_to_nwb/chen2026/`
+**Detailed data notes:** [`conversion_notes.md`](src/dombeck_lab_to_nwb/chen2026/conversion_notes.md), [`lrrk2_investigation.md`](src/dombeck_lab_to_nwb/chen2026/lrrk2_investigation.md)
+
+**Progress: 0 / 27 sessions converted**
+
+---
+
+## Pre-Conversion
+
+- [x] Repo setup
+- [x] Data inspection — ABF channel layout, `_data.mat` column layout, MATLAB HDF5 reference chain
+- [x] Metadata extraction from manuscript — hardware, coordinates, virus, indicator
+- [x] `general_metadata.yaml` — NWBFile fields, Subject fields, session/subject description templates
+- [x] `fiber_photometry.yaml` — device models (optical fibers, LEDs, PMT, filters, dichroics), FiberPhotometryTable rows (4 rows: DLS×470, DLS×405, DMS×470, DMS×405), 12 response-series entries
+- [x] `environment.yaml` — conda env, Python 3.13, neuroconv from GitHub main, ndx-fiber-photometry ≥0.2.3, ndx-ophys-devices ≥0.3.1
+- [x] Raw fiber photometry interface (`raw_fiber_photometry_interface.py`) — demultiplexes 470/405 nm from ABF using `fxn_gen` channel; module-level cache avoids double ABF read
+- [x] Processed fiber photometry interface (`processed_fiber_photometry_interface.py`) — reads `*_data.mat` (MATLAB v7.3 HDF5 via h5py reference chain); exposes corrected470, corrected405, dff470, dff405 at 100 Hz
+- [x] `Chen2026NWBConverter` — RawSignal + IsosbesticControl interfaces wired
+- [x] Stub test passes — Anxa group, animal 4007, session 2025-01-24-0002 ✓
+- [ ] Stub test — Calb group (need to download a Calb ABF)
+- [ ] ABF → animal ID mapping from `LRRK2-animal-list-meta.mat` (which ABF file corresponds to which animal?)
+- [ ] `convert_all_sessions.py` — batch script for all 27 animals
+- [ ] **Pending lab reply** — per-animal sex records, `stim_sequence` 'a' vs 'b' meaning, `initiation` channel meaning (Calb only), Calb DV fiber coordinate, Calb injection DV coordinate, publication DOI, experimenter name(s)
+
+---
+
+## Dataset: Chen et al. 2026 — LRRK2 Fiber Photometry
+
+27 animals total · 1 session per animal · two experimental groups
+
+| Group | Cre line | Recording site | n animals | Animal IDs |
+|-------|----------|----------------|-----------|------------|
+| Anxa-LRRK2 | Anxa1-iCre | DLS (right) | 15 | 3742, 3743, 3947, 3948, 4004, 4005, 4007, 4253, 4398, 4401, 4558, 4561, 4651, 4652, 4885 |
+| Calb-LRRK2 | Calb1-Cre | DMS (right) | 12 | 302, 306, 671, 673, 688, 740, 741, 848, 852, 935, 966, 1803 |
+
+Genotypes per group: WT and LRRK2-G2019S (JAX:030961). Background: C57BL/6J. Age at surgery ~6 months.
+
+### Fiber Photometry
+
+#### Raw fluorescence (from ABF — 2 kHz, irregular timestamps post-demux)
+
+- [x] `FiberPhotometryResponseSeriesRawSignal` — 470 nm functional channel (GRAB-DA3m)
+- [x] `FiberPhotometryResponseSeriesIsosbesticControl` — 405 nm isosbestic control
+- [x] Interfaces implemented and stub tested (Anxa group)
+- [ ] Enable for Calb group (stub test)
+- [ ] Wire into `convert_all_sessions.py`
+
+#### Processed fluorescence (from `*_data.mat` — 100 Hz, regular timestamps)
+
+- [ ] `FiberPhotometryResponseSeriesCorrectedSignal` — baseline-corrected 470 nm (`corrected470`)
+- [ ] `FiberPhotometryResponseSeriesCorrectedIsosbesticControl` — baseline-corrected 405 nm (`corrected405`)
+- [ ] `FiberPhotometryResponseSeriesDfOverF` — % ΔF/F 470 nm, smoothed (`dff470`)
+- [ ] `FiberPhotometryResponseSeriesDfOverFIsosbesticControl` — % ΔF/F 405 nm (`dff405`)
+- [ ] Processed interface implemented (`processed_fiber_photometry_interface.py`)
+- [ ] Wire processed interfaces back into `Chen2026NWBConverter` and `convert_session.py` (currently commented out)
+- [ ] Stub test processed interfaces
+
+### Behavior (from `*_data.mat` — 100 Hz)
+
+- [ ] Treadmill velocity (m/s) → `TimeSeries` or `SpatialSeries` in `processing/behavior`
+- [ ] Treadmill acceleration (m/s²) → `TimeSeries` in `processing/behavior`
+
+### Optogenetics
+
+#### Stimulation events (from `*_data.mat` — 100 Hz binary TTL)
+
+- [ ] Binary opto TTL column → `TimeIntervals` (onset/offset) in `processing/optogenetics` or `stimulus`
+- [ ] Decide: `TimeIntervals` (NWB epochs) vs `TimeSeries` (raw binary)
+
+#### Optogenetic device metadata (ChRmine, 635 nm, SNc)
+
+- [ ] Add ChRmine virus (`pAAV-Ef1a-DIO-ChRmine-mScarlet-WPRE`, AAV5, Addgene #130998, 2.20×10¹³ vg/mL) to `fiber_photometry.yaml` or a separate `optogenetics.yaml`
+- [ ] Add `OptogeneticStimulusSite` + `OptogeneticSeries` metadata for SNc fiber (Doric MFC_400/430-0.66_4.0mm)
+
+### Session Metadata
+
+- [ ] `stim_sequence` ('a' vs 'b', MATLAB categorical) → `NWBFile.lab_meta_data` or `LabMetaData` extension — **needs lab clarification on meaning**
+- [ ] `initiation` channel (Calb only) — store or skip? **Needs lab clarification**
+
+### Post-Conversion
+
+- [ ] Run NWBInspector on a full (non-stub) NWB file
+- [ ] Fix any NWBInspector warnings
+- [ ] Setup Dandiset (embargoed until publication — DOI pending)
+- [ ] Upload all 27 NWB files to DANDI
+- [ ] Example notebook — local read + key figure reproduction
+
+---
+
+## Open Questions (lab confirmation needed)
+
+| # | Question | Affects |
+|---|----------|---------|
+| 1 | Per-animal sex records | `Subject.sex` (currently `U` placeholder) |
+| 2 | `stim_sequence` 'a' vs 'b' meaning | Session metadata field |
+| 3 | `initiation` channel meaning (Calb only) | Whether to store, and how |
+| 4 | Calb group DV fiber coordinate | `FiberInsertion.depth_in_mm` (currently estimated from ferrule length 3 mm) |
+| 5 | Calb group GRAB-DA3m injection DV | `FiberPhotometryVirusInjection.dv_in_mm` (currently `2.9` estimate) |
+| 6 | Publication DOI | `NWBFile.related_publications` |
+| 7 | Experimenter name(s) who collected photometry data | `NWBFile.experimenter` |
+| 8 | Hamamatsu H10770PA-40 gain value | `PhotodetectorModel.gain` (wavelength range 300–740 nm already set) |


### PR DESCRIPTION
This pull request introduces the initial NWB conversion pipeline for the Dombeck lab's LRRK2 fiber photometry dataset (Chen et al., 2026). It adds a new submodule with conversion scripts, a custom raw fiber photometry interface for demultiplexing ABF files, environment setup, and extensive documentation. The main contributions are organized as follows:

**Conversion pipeline and code:**
* Added the `chen2026` submodule with a main conversion script (`convert_session.py`) that orchestrates conversion of a single ABF session to NWB, using group/genotype-specific metadata and a flexible interface wiring system.
* Implemented `Chen2026RawFiberPhotometryInterface`, a custom interface that reads multiplexed 520 nm fluorescence signals from ABF files, demultiplexes them into 470 nm (functional) and 405 nm (isosbestic) streams, and exposes them as NWB FiberPhotometryResponseSeries.

**Environment and reproducibility:**
* Added `environment.yaml` specifying all dependencies (Python 3.13, neuroconv from GitHub, ndx-fiber-photometry, pyabf, etc.) for reproducible setup via conda.

**Documentation and metadata:**
* Added a detailed `README.md` describing installation, folder structure, key scripts, and usage instructions for the conversion pipeline.
* Added comprehensive `conversion_notes.md` documenting dataset details, experimental design, data and channel structure, hardware metadata, comparison with previous pipelines, and open questions for lab confirmation.

Example file for reference: https://drive.google.com/drive/folders/1fJattBy1iEiQfwktkm7uxspJPUDiu1sD