### PR TITLE
Add processed fiber photometry for LRRK2 dataset

### DIFF
--- a/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
+++ b/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
@@ -124,9 +124,11 @@ Note: `stim_sequence` is a MATLAB categorical — pymatreader cannot parse it. U
 | Detector | Hamamatsu H10770PA-40 GaAsP PMT |
 | Amplifier | Stanford Research Systems SR570 |
 | DAQ | Axon Digidata 1550B, 2 kHz |
-| Photometry fiber (Anxa/DLS) | Doric MFC_200/250-0.66_2.0mm, 200 µm, 0.66 NA, 2 mm length/depth |
-| Photometry fiber (Calb/DMS) | Doric MFC_00/250-0.66_3.0mm, 200 µm, 0.66 NA, 3 mm length/depth |
-| Opto fiber (SNc, both groups) | Doric MFC_400/430-0.66_4.0mm, 400 µm, 0.66 NA, 4 mm length/depth |
+| Photometry fiber (Anxa/DLS) | Doric MFC_200/250-0.66_2.0mm_ZF1.25(G)_FLT, 200 µm, 0.66 NA, 2 mm depth |
+| Photometry fiber (Calb/DMS) | Doric MFC_00/250-0.66_3.0mm_ZF1.25(G)_FLT, 200 µm, 0.66 NA, 3 mm depth |
+| Opto fiber (SNc, both groups) | Doric MFC_400/430-0.66_4.0mm_TS3.0_C60, 400 µm, 0.66 NA, 4 mm depth |
+| Opto LED | Doric LEDFRJ_635 (635 nm red LED); controlled by Doric Studio software |
+| Opto control | Stimulation trains triggered by custom LabVIEW script |
 
 Fiber implant DV depth = ferrule length (Doric convention), referenced from dura surface.
 
@@ -150,6 +152,75 @@ Fiber implant DV depth = ferrule length (Doric convention), referenced from dura
 
 ---
 
+### Time Alignment
+
+#### Recording clocks and reference frame
+
+All data in a single session is acquired on a single clock: the **Axon Digidata 1550B** DAQ, sampling all six channels (or five, for the Anxa open-loop setup) at 2000 Hz. Time zero (`t = 0`) for the NWB file is defined by the ABF recording start — the moment the Digidata started acquiring. All raw data timestamps are in seconds relative to this start.
+
+The **session start time** (`NWBFile.session_start_time`) is derived from the ABF file header (Axon `uFileStartDateTime` field, UTC). This is the absolute wall-clock time at the moment the Digidata started. All relative timestamps in the NWB file are seconds elapsed from that moment.
+
+#### Raw fiber photometry (470 nm signal + 405 nm isosbestic)
+
+- **Source:** ABF file, `520sig` channel (continuous analog, 2000 Hz).
+- **Demultiplexing** (`_load_and_demux` in `raw_fiber_photometry_interface.py`):
+  1. Read all 2000 Hz samples from `520sig` and `fxn_gen`.
+  2. Build a 2000-sample-per-second time vector: `timestamps = np.arange(n) / abf.dataRate` — these are seconds since DAQ start, in the ABF clock.
+  3. Classify each sample: `wave470 = fxn_gen > 1 V`, `wave405 = ~wave470`.
+  4. Mark transition samples as borders, mirroring the MATLAB logic:
+     - `border405 = [0, |diff(wave405)|]` (leading-edge flag)
+     - `border470 = [|diff(wave470)|, 1]` (trailing-edge flag; last sample always flagged)
+     - `border = (border405 + border470) > 0`
+  5. Select retained samples and their timestamps:
+     - 470 nm: `sig520[wave470 & ~border]`, `timestamps[wave470 & ~border]`
+     - 405 nm: `sig520[wave405 & ~border]`, `timestamps[wave405 & ~border]`
+- **Timestamps stored in NWB:** the subset of ABF timestamps corresponding to retained samples — explicit, irregular, in the ABF clock. The 470 nm and 405 nm series have slightly different sample counts (e.g. 1,055,733 vs 1,055,138 in the example session) because the LED duty cycle is not exactly 50/50 and each channel discards its own transition samples.
+- **Time range:** `t ≈ 0 s` to `t ≈ 1319 s` (example session; spans the full ABF recording).
+- **NWB location:** `acquisition/FiberPhotometryResponseSeriesRawSignal` (470 nm) and `acquisition/FiberPhotometryResponseSeriesIsosbesticControl` (405 nm).
+
+#### Session start time
+
+`NWBFile.session_start_time` is the wall-clock datetime read directly from the ABF header (`abf.abfDateTime`). The ABF stores it without timezone info; the lab is at Northwestern University (Chicago), so `America/Chicago` is applied. This is also returned by `get_metadata()` so it flows automatically into the NWB file without any manual override.
+
+#### Processed fiber photometry and all `_data.mat` signals
+
+The MATLAB processing script (`LRRK2_binning_and_processing.m`) reads the raw ABF and re-bins all signals into **camera-trigger-aligned bins at 100 Hz**. It detects rising edges in the `camera` ABF channel (square wave 0 / 3.3 V, 100 Hz) and uses each trigger as a bin boundary. The binned outputs are stored in `*_data.mat`.
+
+**Critical offset:** the camera does not start triggering immediately at recording start. In the example session (animal 4007), the first camera trigger fires at **t ≈ 21.06 s** into the ABF recording. Consequently all `_data.mat` columns (corrected signal, ΔF/F, TTL, velocity, acceleration) begin at ~21 s, not at 0 s. Storing them with `starting_time = 0` would shift all processed data 21 s earlier than reality and misalign them against the raw FP.
+
+**Alignment solution:** `_read_mat()` detects the camera trigger rising edges from the `camera` column (threshold 1.0 V, 2000 Hz), computes `trigger_times = rising_edge_sample_index / 2000.0`, and stores them as `"camera_trigger_times"` in the cache. All 100 Hz interfaces use these times as explicit timestamps:
+
+| Interface | Timestamps source |
+|-----------|------------------|
+| Processed FP (`corrected470`, `corrected405`, `dff470`, `dff405`) | `camera_trigger_times` |
+| Behavior (`velocity`, `acceleration`) | `camera_trigger_times` |
+| Optogenetic epochs (TTL) | `camera_trigger_times[start_index]` and `camera_trigger_times[stop_index]` |
+
+The trigger spacing is nominally 10 ms (100 Hz) with ±0.5 ms quantization noise from the 2 kHz sampling grid. This means 129,307 triggers align to 129,307 samples in each processed column.
+
+**Verified alignment (example session):**
+
+| Signal | Time range in NWB | Notes |
+|--------|-------------------|-------|
+| Raw FP (470 nm) | 0.000 – 1319.295 s | Full ABF recording |
+| Raw FP (405 nm) | 0.000 – 1319.295 s | Same ABF clock |
+| Processed FP / ΔF/F | 21.061 – 1313.823 s | Camera-trigger-aligned |
+| Behavior (velocity, acceleration) | 21.061 – 1313.823 s | Same camera triggers |
+| Optogenetic epochs | 51.764 – ... s | TTL first epoch; within processed range ✓ |
+
+#### Optogenetic stimulation epochs
+
+- **Source:** `TTL` column in `_data.mat` (uint8, 0 or 1, 100 Hz), which encodes whether the 635 nm LED was on during each camera-trigger bin.
+- **Epoch extraction:** contiguous runs of `TTL = 1` are detected. At 10 ms/sample, the 8 ms on / 8 ms off pulse pattern within a 500 ms train appears as a single block of ~33 consecutive samples (~330 ms) because the 8 ms on-phase dominates each 10 ms bin. Each extracted epoch row corresponds to one 500 ms pulse train.
+- **Epoch times:** `start_time = camera_trigger_times[first_high_sample]`, `stop_time = camera_trigger_times[first_low_sample_after_epoch]`. These are in the ABF clock, aligned with all other signals.
+- **Note:** stimulation begins at ~30–50 s into the session (well after the ~21 s camera-start offset), so all 122 epochs fall within the processed FP time range.
+
+#### Summary: what defines `t = 0` for this dataset
+
+`t = 0` is the **Axon Digidata recording start** (ADC enabled), captured as an absolute UTC datetime in the ABF header and stored in `NWBFile.session_start_time`. All signals are in seconds elapsed from that moment. The raw FP starts at `t ≈ 0 s`; the processed / behavior / opto signals start at `t ≈ 21 s` (first camera trigger). There is no separate synchronization signal between the ABF and any other acquisition device — everything is on one DAQ.
+
+---
+
 ### Implementation Notes
 
 #### Processed series routing to `processing/ophys`
@@ -165,10 +236,9 @@ A TODO comment in the interface marks this for removal once a neuroconv PR adds 
 
 ### Open Questions (needs lab confirmation)
 
-1. **`stim_sequence` 'a' vs 'b'**: 18 animals have 'a', 9 have 'b', mixed across groups and genotypes. What does this distinguish?
+1. **`stim_sequence` 'a' vs 'b'**: 18 animals have 'a', 9 have 'b', mixed across groups and genotypes. Likely encodes the pseudorandom power order (0.1/0.5/1.0/4.0 mW). Needed to set per-epoch `power_in_mW` in `OptogeneticEpochsTable`.
 2. **`initiation` channel**: What does this signal represent? Store in NWB?
 3. **Per-animal sex records** — manuscript says both sexes used but no individual records confirmed
-4. **Photometry fiber DV coordinate for Calb group** — not stated in manuscript
-5. **GRAB-DA3m injection DV for Calb group** — not stated in manuscript
-6. **Publication DOI** — manuscript not yet published
-7. **Experimenter names** — confirm which authors collected the photometry data
+4. **Publication DOI** — manuscript not yet published; Zenodo: 10.5281/zenodo.20244434
+5. **Experimenter names** — confirm which authors collected the photometry data
+6. **`power_in_mW` per epoch** — currently NaN in OptogeneticEpochsTable; resolve via stim_sequence 'a'/'b' mapping with lab

--- a/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
+++ b/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
@@ -4,7 +4,7 @@
 
 **Manuscript:** "Leucine-rich repeat kinase 2 impairs the release sites of Parkinson's disease vulnerable dopamine axons", Chen, He et al. (in preparation)
 **Analysis code:** https://github.com/DombeckLab/lrrk2_photometry_analysis (Zenodo: 10.5281/zenodo.20244434)
-**Status:** Data inspection complete, metadata extracted from manuscript, code not yet written.
+**Status:** All fiber photometry interfaces implemented and stub-tested (27/27 sessions pass). Full conversion run pending.
 **Detailed notes:** see `lrrk2_investigation.md`
 
 ---
@@ -100,6 +100,11 @@ MATLAB table, one row per file. Read via h5py (`#subsystem#/MCOS`): column names
 
 Note: `stim_sequence` is a MATLAB categorical — pymatreader cannot parse it. Use h5py `MCOS[8]` (uint8), map 1→'a', 2→'b'.
 
+**Column order verified from `LRRK2_binning_and_processing.m`** — confirmed the 10-column layout above matches the MATLAB script output exactly. Processing steps also verified:
+- `corrected470`/`corrected405`: output of `baselineCorrect()` — sliding 8th-percentile baseline (window=2001 samples, subtraction factor 0.85)
+- `dff470`/`dff405`: output of `df_f()` — `(signal − F0) / F0 × 100`, then smoothed with `movmean(20)` (20-sample moving mean at 100 Hz = 200 ms window)
+- Binning: camera-trigger-aligned, `fps=100`, velocity calibration factor `calib = 0.6766 × 2 = 1.3532`
+
 ---
 
 ### Key Hardware Metadata (from manuscript)
@@ -142,6 +147,19 @@ Fiber implant DV depth = ferrule length (Doric convention), referenced from dura
 - New channels: `initiation` (Calb only), `stim_sequence` (session metadata)
 
 **ndx-fiber-photometry version:** use v0.2.x API (ndx-ophys-devices) — do **not** replicate the v0.1.0 approach used in he_embargo_2024 and azcorra2023.
+
+---
+
+### Implementation Notes
+
+#### Processed series routing to `processing/ophys`
+
+`BaseFiberPhotometryInterface` (neuroconv) hardcodes `nwbfile.add_acquisition(response_series)` with no override point for the target container. As a workaround, `Chen2026ProcessedFiberPhotometryInterface` overrides `add_to_nwbfile` to:
+1. Call `super().add_to_nwbfile(...)` (adds to acquisition)
+2. Delete the series from `nwbfile.acquisition` via `LabelledDict.__delitem__`
+3. Create `nwbfile.processing["ophys"]` if absent, then add the series there
+
+A TODO comment in the interface marks this for removal once a neuroconv PR adds a `parent_container: Literal["acquisition", "processing/ophys"] = "acquisition"` parameter to `BaseFiberPhotometryInterface.add_to_nwbfile`. The pattern already exists in `roiextractors.py` (lines 460–464) and uses the `get_module` utility already imported in the fiber photometry module.
 
 ---
 

--- a/src/dombeck_lab_to_nwb/chen2026/convert_all_sessions.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_all_sessions.py
@@ -71,9 +71,11 @@ def _session_to_nwb(session: dict, data_dir: Path, nwb_output_dir: Path, stub_te
     group_dir = f"{group}-LRRK2"
 
     abf_file = data_dir / group_dir / session["abf_filename"]
+    mat_file = data_dir / group_dir / animal_id / f"{animal_id}_data.mat"
 
     convert_session(
         file_path=abf_file,
+        mat_file=mat_file,
         nwb_folder_path=nwb_output_dir,
         subject_id=animal_id,
         group=group,

--- a/src/dombeck_lab_to_nwb/chen2026/convert_session.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_session.py
@@ -20,18 +20,18 @@ GROUP_TO_METADATA_KEYS = {
     "Anxa": {
         "RawSignal": "raw_signal_anxa",
         "IsosbesticControl": "isosbestic_anxa",
-        # "CorrectedSignal": "corrected_signal_anxa",
-        # "CorrectedIsosbestic": "corrected_isosbestic_anxa",
-        # "DfOverF": "dff_anxa",
-        # "DfOverFIsosbestic": "dff_isosbestic_anxa",
+        "CorrectedSignal": "corrected_signal_anxa",
+        "CorrectedIsosbestic": "corrected_isosbestic_anxa",
+        "DfOverF": "dff_anxa",
+        "DfOverFIsosbestic": "dff_isosbestic_anxa",
     },
     "Calb": {
         "RawSignal": "raw_signal_calb",
         "IsosbesticControl": "isosbestic_calb",
-        # "CorrectedSignal": "corrected_signal_calb",
-        # "CorrectedIsosbestic": "corrected_isosbestic_calb",
-        # "DfOverF": "dff_calb",
-        # "DfOverFIsosbestic": "dff_isosbestic_calb",
+        "CorrectedSignal": "corrected_signal_calb",
+        "CorrectedIsosbestic": "corrected_isosbestic_calb",
+        "DfOverF": "dff_calb",
+        "DfOverFIsosbestic": "dff_isosbestic_calb",
     },
 }
 
@@ -47,9 +47,10 @@ def convert_session(
     subject_id: str,
     group: Literal["Anxa", "Calb"] = "Anxa",
     genotype: Literal["WT", "GS"] = "WT",
+    mat_file: str | Path | None = None,
     stub_test: bool = False,
 ) -> None:
-    """Convert one ABF recording to NWB.
+    """Convert one ABF (and optionally its *_data.mat) recording to NWB.
 
     Parameters
     ----------
@@ -63,6 +64,9 @@ def convert_session(
         Experimental group: "Anxa" or "Calb".
     genotype : Literal["WT", "GS"], default "WT"
         Genotype: "WT" or "GS" (LRRK2-G2019S).
+    mat_file : str | Path | None
+        Path to the *_data.mat file. When provided the four processed
+        fluorescence series (corrected470/405, dff470/405) are also written.
     stub_test : bool
         If True write only the first 100 samples (for CI / smoke tests).
     """
@@ -81,19 +85,47 @@ def convert_session(
     subject_id += f"-{group.lower()}-{genotype.lower()}"
     nwbfile_path = nwb_folder_path / f"sub-{subject_id}_ses-{session_id}.nwb"
 
-    # Raw interfaces
+    # Raw interfaces — always present
     source_data: dict = {
         "RawSignal": {
-            "file_path": file_path,
+            "file_path": str(file_path),
             "stream_names": ["470nm"],
             "metadata_key": metadata_keys["RawSignal"],
         },
         "IsosbesticControl": {
-            "file_path": file_path,
+            "file_path": str(file_path),
             "stream_names": ["405nm"],
             "metadata_key": metadata_keys["IsosbesticControl"],
         },
     }
+
+    # Processed interfaces — present only when mat_file is provided
+    if mat_file is not None:
+        mat_file = str(mat_file)
+        source_data.update(
+            {
+                "CorrectedSignal": {
+                    "file_path": mat_file,
+                    "stream_names": ["corrected470"],
+                    "metadata_key": metadata_keys["CorrectedSignal"],
+                },
+                "CorrectedIsosbestic": {
+                    "file_path": mat_file,
+                    "stream_names": ["corrected405"],
+                    "metadata_key": metadata_keys["CorrectedIsosbestic"],
+                },
+                "DfOverF": {
+                    "file_path": mat_file,
+                    "stream_names": ["dff470"],
+                    "metadata_key": metadata_keys["DfOverF"],
+                },
+                "DfOverFIsosbestic": {
+                    "file_path": mat_file,
+                    "stream_names": ["dff405"],
+                    "metadata_key": metadata_keys["DfOverFIsosbestic"],
+                },
+            }
+        )
 
     converter = Chen2026NWBConverter(source_data=source_data)
     metadata = converter.get_metadata()
@@ -121,6 +153,15 @@ def convert_session(
         "RawSignal": {"stub_test": stub_test},
         "IsosbesticControl": {"stub_test": stub_test},
     }
+    if mat_file is not None:
+        conversion_options.update(
+            {
+                "CorrectedSignal": {"stub_test": stub_test},
+                "CorrectedIsosbestic": {"stub_test": stub_test},
+                "DfOverF": {"stub_test": stub_test},
+                "DfOverFIsosbestic": {"stub_test": stub_test},
+            }
+        )
 
     converter.run_conversion(
         nwbfile_path=nwbfile_path,
@@ -133,16 +174,18 @@ def convert_session(
 
 if __name__ == "__main__":
     # --- Edit these paths and parameters before running ---
-    abf_file = Path("/Users/weian/lrrk2_data/Anxa-LRRK2/2025_01_24_0002.abf")
+    abf_file = Path("/Users/weian/lrrk2_data/Anxa-LRRK2/2025_08_13_0005.abf")
+    mat_file = Path("/Users/weian/lrrk2_data/Anxa-LRRK2/4007/4007_data.mat")  # set to None to skip processed
     output_path = Path("/Users/weian/lrrk2_data/nwb-output")
     animal_id = "4007"
     group = "Anxa"  # "Anxa" or "Calb"
-    genotype = "WT"  # "WT" or "GS"
+    genotype = "GS"  # "WT" or "GS"
     stub_test = False
     # ------------------------------------------------------
 
     convert_session(
         file_path=abf_file,
+        mat_file=mat_file,
         nwb_folder_path=output_path,
         subject_id=animal_id,
         group=group,

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/__init__.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/__init__.py
@@ -1,5 +1,7 @@
+from .processed_fiber_photometry_interface import Chen2026ProcessedFiberPhotometryInterface
 from .raw_fiber_photometry_interface import Chen2026RawFiberPhotometryInterface
 
 __all__ = [
     "Chen2026RawFiberPhotometryInterface",
+    "Chen2026ProcessedFiberPhotometryInterface",
 ]

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/processed_fiber_photometry_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/processed_fiber_photometry_interface.py
@@ -1,0 +1,160 @@
+"""Processed fiber photometry interface for Chen et al. 2026 (LRRK2 dataset).
+
+Reads one of four baseline-corrected / ΔF/F streams from the per-animal
+*_data.mat file produced by LRRK2_binning_and_processing.m:
+
+  "corrected470"  — baseline-subtracted 470 nm signal (baselineCorrect)
+  "corrected405"  — baseline-subtracted 405 nm isosbestic signal
+  "dff470"        — % ΔF/F of the corrected 470 nm trace (smoothed, 20-sample moving mean)
+  "dff405"        — % ΔF/F of the corrected 405 nm trace (smoothed, 20-sample moving mean)
+
+All four streams are at 100 Hz (camera-trigger-aligned binning). The *_data.mat
+file is a MATLAB v7.3 HDF5 file containing a table class object; it is read
+directly with h5py via the reference-chain structure documented below.
+
+Column order in the MATLAB table (g-ref index → column name):
+  0 filename, 1 corrected470, 2 corrected405, 3 dff470, 4 dff405,
+  5 TTL, 6 velocity, 7 acceleration, 8 camera, 9 stim_sequence
+"""
+
+from pathlib import Path
+
+import numpy as np
+from neuroconv.datainterfaces.fiber_photometry.basefiberphotometryinterface import (
+    BaseFiberPhotometryInterface,
+)
+
+_COLUMNS = [
+    "filename",
+    "corrected470",
+    "corrected405",
+    "dff470",
+    "dff405",
+    "TTL",
+    "velocity",
+    "acceleration",
+    "camera",
+    "stim_sequence",
+]
+
+# Module-level cache keyed by file_path
+_MAT_CACHE: dict[str, dict] = {}
+
+
+def _read_mat(file_path: str) -> dict:
+    """Read *_data.mat and return {column_name: np.ndarray} (cached)."""
+    if file_path in _MAT_CACHE:
+        return _MAT_CACHE[file_path]
+
+    import h5py
+
+    result: dict = {}
+    with h5py.File(file_path, "r") as f:
+        g_ds = f["#refs#"]["g"]  # 10-element ref array, one per column
+
+        for col_idx, col_name in enumerate(_COLUMNS):
+            outer_ref = g_ds[col_idx, 0]
+            outer = f[outer_ref]
+
+            if not (isinstance(outer, h5py.Dataset) and outer.dtype == object):
+                continue
+
+            inner_ref = outer[0, 0]
+            inner = f[inner_ref]
+
+            if not isinstance(inner, h5py.Dataset):
+                continue
+
+            raw = inner[()]
+            if raw.dtype == np.uint16:
+                result[col_name] = "".join(chr(c) for c in raw.flatten())
+            elif raw.dtype in (np.float64, np.float32):
+                result[col_name] = raw.flatten().astype(np.float64)
+            elif raw.dtype == np.uint8:
+                result[col_name] = raw.flatten()
+            # stim_sequence (object/uint32 MCOS) and camera (2 kHz, skip) left out
+
+    _MAT_CACHE[file_path] = result
+    return result
+
+
+class Chen2026ProcessedFiberPhotometryInterface(BaseFiberPhotometryInterface):
+    """Processed fiber photometry from *_data.mat file (Chen et al. 2026).
+
+    Each instance writes one FiberPhotometryResponseSeries at 100 Hz.
+    Instantiate with one of the four processed stream names:
+
+      stream_names=["corrected470"]  → FiberPhotometryResponseSeriesCorrectedSignal
+      stream_names=["corrected405"]  → FiberPhotometryResponseSeriesCorrectedIsosbesticControl
+      stream_names=["dff470"]        → FiberPhotometryResponseSeriesDfOverF
+      stream_names=["dff405"]        → FiberPhotometryResponseSeriesDfOverFIsosbesticControl
+
+    Pass ``metadata_key`` matching an entry in ``fiber_photometry.yaml``:
+      "corrected_signal_{anxa|calb}", "corrected_isosbestic_{anxa|calb}",
+      "dff_{anxa|calb}", "dff_isosbestic_{anxa|calb}"
+    """
+
+    display_name = "Chen2026 Processed Fiber Photometry (_data.mat)"
+    associated_suffixes = (".mat",)
+    info = "Interface for processed fiber photometry from MATLAB _data.mat files."
+
+    PROCESSED_STREAMS = ("corrected470", "corrected405", "dff470", "dff405")
+    SAMPLING_RATE = 100.0
+
+    @classmethod
+    def get_available_streams(cls, file_path: str | Path) -> list[str]:
+        return list(cls.PROCESSED_STREAMS)
+
+    def __init__(
+        self,
+        *,
+        file_path: str | Path,
+        stream_names: list[str],
+        metadata_key: str | None = None,
+        verbose: bool = False,
+    ):
+        """
+        Parameters
+        ----------
+        file_path : str | Path
+            Path to the *_data.mat file.
+        stream_names : list of str
+            Which processed stream to expose. One of "corrected470",
+            "corrected405", "dff470", "dff405".
+        metadata_key : str | None
+            Key into metadata["FiberPhotometry"] for this series entry.
+            Must match an entry in fiber_photometry.yaml.
+        verbose : bool
+        """
+        super().__init__(
+            stream_names=stream_names,
+            metadata_key=metadata_key,
+            file_path=str(file_path),
+            verbose=verbose,
+        )
+
+    def _get_stream_data(self, *, stream_name: str) -> np.ndarray:
+        return _read_mat(self.source_data["file_path"])[stream_name]
+
+    def _get_stream_timestamps(self, *, stream_name: str) -> np.ndarray:
+        data = _read_mat(self.source_data["file_path"])[stream_name]
+        return np.arange(len(data), dtype=np.float64) / self.SAMPLING_RATE
+
+    # TODO: this should be fixed in BaseFiberPhotometryInterface
+    """
+     The ophys imaging interface already uses parent_container: Literal["acquisition", "processing/ophys"].
+     That's the exact pattern needed for BaseFiberPhotometryInterface. The PR to neuroconv would be straightforward:
+     1. Add parent_container: Literal["acquisition", "processing/ophys"] = "acquisition" to BaseFiberPhotometryInterface.add_to_nwbfile
+    2. Replace the hardcoded nwbfile.add_acquisition(response_series) with the same conditional logic the ophys interface uses
+    """
+
+    def add_to_nwbfile(self, nwbfile, metadata, **conversion_options):
+        super().add_to_nwbfile(nwbfile=nwbfile, metadata=metadata, **conversion_options)
+
+        series_name = metadata["FiberPhotometry"][self.metadata_key]["name"]
+        series = nwbfile.acquisition[series_name]
+        del nwbfile.acquisition[series_name]
+
+        if "ophys" not in nwbfile.processing:
+            nwbfile.create_processing_module("ophys", "Processed optical physiology data.")
+        nwbfile.processing["ophys"].add(series)

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/processed_fiber_photometry_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/processed_fiber_photometry_interface.py
@@ -41,8 +41,19 @@ _COLUMNS = [
 _MAT_CACHE: dict[str, dict] = {}
 
 
+_CAMERA_SAMPLE_RATE = 2000.0  # Hz — raw ABF / camera-channel sampling rate
+_CAMERA_TRIGGER_THRESHOLD = 1.0  # V — threshold for camera trigger detection
+
+
 def _read_mat(file_path: str) -> dict:
-    """Read *_data.mat and return {column_name: np.ndarray} (cached)."""
+    """Read *_data.mat and return {column_name: np.ndarray} (cached).
+
+    In addition to the named columns, the returned dict contains:
+      "camera_trigger_times" — timestamps (in seconds, ABF clock) of each
+          camera trigger rising edge. These are the actual sample times for
+          all 100 Hz columns and are used as explicit timestamps in NWB to
+          align processed data with the raw ABF recording.
+    """
     if file_path in _MAT_CACHE:
         return _MAT_CACHE[file_path]
 
@@ -72,7 +83,17 @@ def _read_mat(file_path: str) -> dict:
                 result[col_name] = raw.flatten().astype(np.float64)
             elif raw.dtype == np.uint8:
                 result[col_name] = raw.flatten()
-            # stim_sequence (object/uint32 MCOS) and camera (2 kHz, skip) left out
+            # stim_sequence (object/uint32 MCOS) left unread
+
+    # Derive camera trigger timestamps from the 2 kHz camera TTL channel.
+    # The processed 100 Hz columns are binned on camera trigger rising edges;
+    # using these times as explicit timestamps aligns the processed data to
+    # the ABF recording clock.
+    if "camera" in result:
+        cam = result.pop("camera")  # discard raw 2 kHz signal after processing
+        above = cam > _CAMERA_TRIGGER_THRESHOLD
+        rising_indices = np.where(np.diff(above.astype(np.int8)) == 1)[0]
+        result["camera_trigger_times"] = rising_indices / _CAMERA_SAMPLE_RATE
 
     _MAT_CACHE[file_path] = result
     return result
@@ -137,8 +158,7 @@ class Chen2026ProcessedFiberPhotometryInterface(BaseFiberPhotometryInterface):
         return _read_mat(self.source_data["file_path"])[stream_name]
 
     def _get_stream_timestamps(self, *, stream_name: str) -> np.ndarray:
-        data = _read_mat(self.source_data["file_path"])[stream_name]
-        return np.arange(len(data), dtype=np.float64) / self.SAMPLING_RATE
+        return _read_mat(self.source_data["file_path"])["camera_trigger_times"]
 
     # TODO: this should be fixed in BaseFiberPhotometryInterface
     """

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/processed_fiber_photometry_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/processed_fiber_photometry_interface.py
@@ -93,7 +93,11 @@ def _read_mat(file_path: str) -> dict:
         cam = result.pop("camera")  # discard raw 2 kHz signal after processing
         above = cam > _CAMERA_TRIGGER_THRESHOLD
         rising_indices = np.where(np.diff(above.astype(np.int8)) == 1)[0]
-        result["camera_trigger_times"] = rising_indices / _CAMERA_SAMPLE_RATE
+        trigger_times = rising_indices / _CAMERA_SAMPLE_RATE
+        # MATLAB bins exactly N samples starting at each trigger; Python edge
+        # detection occasionally finds one extra trailing trigger — trim to match.
+        data_len = len(result.get("corrected470", result.get("dff470", trigger_times)))
+        result["camera_trigger_times"] = trigger_times[:data_len]
 
     _MAT_CACHE[file_path] = result
     return result

--- a/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/metadata/fiber_photometry.yaml
@@ -338,93 +338,93 @@ FiberPhotometry:
     fiber_photometry_table_region:
       - dms_405
     fiber_photometry_table_region_description: "DMS 405 nm isosbestic control channel."
-#
-#  # ---------------------------------------------------------------------------
-#  # Processed response series — from *_data.mat (100 Hz, camera-trigger-aligned).
-#  # baselineCorrect: sliding-window 8th-percentile subtract-then-divide (window=2001).
-#  # df_f: (corrected - F0) / F0 * 100, F0 = 8th percentile; smoothed with 20-sample moving mean.
-#  # ---------------------------------------------------------------------------
-#
-#  # Anxa-LRRK2 group (DLS) — baseline-corrected 470 nm
-#  corrected_signal_anxa:
-#    name: FiberPhotometryResponseSeriesCorrectedSignal
-#    description: >
-#      Baseline-corrected GRAB-DA3m 470 nm fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
-#      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
-#      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
-#    fiber_photometry_table_region:
-#      - dls_470
-#    fiber_photometry_table_region_description: "DLS 470 nm functional channel (baseline-corrected)."
-#
-#  # Anxa-LRRK2 group (DLS) — baseline-corrected 405 nm isosbestic
-#  corrected_isosbestic_anxa:
-#    name: FiberPhotometryResponseSeriesCorrectedIsosbesticControl
-#    description: >
-#      Baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
-#      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
-#      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
-#    fiber_photometry_table_region:
-#      - dls_405
-#    fiber_photometry_table_region_description: "DLS 405 nm isosbestic control channel (baseline-corrected)."
-#
-#  # Anxa-LRRK2 group (DLS) — ΔF/F 470 nm
-#  dff_anxa:
-#    name: FiberPhotometryResponseSeriesDfOverF
-#    description: >
-#      % ΔF/F of baseline-corrected GRAB-DA3m 470 nm fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
-#      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
-#    fiber_photometry_table_region:
-#      - dls_470
-#    fiber_photometry_table_region_description: "DLS 470 nm functional channel (% ΔF/F, smoothed)."
-#
-#  # Anxa-LRRK2 group (DLS) — ΔF/F 405 nm isosbestic
-#  dff_isosbestic_anxa:
-#    name: FiberPhotometryResponseSeriesDfOverFIsosbesticControl
-#    description: >
-#      % ΔF/F of baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
-#      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
-#    fiber_photometry_table_region:
-#      - dls_405
-#    fiber_photometry_table_region_description: "DLS 405 nm isosbestic control channel (% ΔF/F, smoothed)."
-#
-#  # Calb-LRRK2 group (DMS) — baseline-corrected 470 nm
-#  corrected_signal_calb:
-#    name: FiberPhotometryResponseSeriesCorrectedSignal
-#    description: >
-#      Baseline-corrected GRAB-DA3m 470 nm fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
-#      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
-#      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
-#    fiber_photometry_table_region:
-#      - dms_470
-#    fiber_photometry_table_region_description: "DMS 470 nm functional channel (baseline-corrected)."
-#
-#  # Calb-LRRK2 group (DMS) — baseline-corrected 405 nm isosbestic
-#  corrected_isosbestic_calb:
-#    name: FiberPhotometryResponseSeriesCorrectedIsosbesticControl
-#    description: >
-#      Baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
-#      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
-#      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
-#    fiber_photometry_table_region:
-#      - dms_405
-#    fiber_photometry_table_region_description: "DMS 405 nm isosbestic control channel (baseline-corrected)."
-#
-#  # Calb-LRRK2 group (DMS) — ΔF/F 470 nm
-#  dff_calb:
-#    name: FiberPhotometryResponseSeriesDfOverF
-#    description: >
-#      % ΔF/F of baseline-corrected GRAB-DA3m 470 nm fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
-#      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
-#    fiber_photometry_table_region:
-#      - dms_470
-#    fiber_photometry_table_region_description: "DMS 470 nm functional channel (% ΔF/F, smoothed)."
-#
-#  # Calb-LRRK2 group (DMS) — ΔF/F 405 nm isosbestic
-#  dff_isosbestic_calb:
-#    name: FiberPhotometryResponseSeriesDfOverFIsosbesticControl
-#    description: >
-#      % ΔF/F of baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
-#      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
-#    fiber_photometry_table_region:
-#      - dms_405
-#    fiber_photometry_table_region_description: "DMS 405 nm isosbestic control channel (% ΔF/F, smoothed)."
+
+  # ---------------------------------------------------------------------------
+  # Processed response series — from *_data.mat (100 Hz, camera-trigger-aligned).
+  # baselineCorrect: sliding-window 8th-percentile subtract-then-divide (window=2001).
+  # df_f: (corrected - F0) / F0 * 100, F0 = 8th percentile; smoothed with 20-sample moving mean.
+  # ---------------------------------------------------------------------------
+
+  # Anxa-LRRK2 group (DLS) — baseline-corrected 470 nm
+  corrected_signal_anxa:
+    name: FiberPhotometryResponseSeriesCorrectedSignal
+    description: >
+      Baseline-corrected GRAB-DA3m 470 nm fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
+      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
+      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
+    fiber_photometry_table_region:
+      - dls_470
+    fiber_photometry_table_region_description: "DLS 470 nm functional channel (baseline-corrected)."
+
+  # Anxa-LRRK2 group (DLS) — baseline-corrected 405 nm isosbestic
+  corrected_isosbestic_anxa:
+    name: FiberPhotometryResponseSeriesCorrectedIsosbesticControl
+    description: >
+      Baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
+      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
+      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
+    fiber_photometry_table_region:
+      - dls_405
+    fiber_photometry_table_region_description: "DLS 405 nm isosbestic control channel (baseline-corrected)."
+
+  # Anxa-LRRK2 group (DLS) — ΔF/F 470 nm
+  dff_anxa:
+    name: FiberPhotometryResponseSeriesDfOverF
+    description: >
+      % ΔF/F of baseline-corrected GRAB-DA3m 470 nm fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
+      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
+    fiber_photometry_table_region:
+      - dls_470
+    fiber_photometry_table_region_description: "DLS 470 nm functional channel (% ΔF/F, smoothed)."
+
+  # Anxa-LRRK2 group (DLS) — ΔF/F 405 nm isosbestic
+  dff_isosbestic_anxa:
+    name: FiberPhotometryResponseSeriesDfOverFIsosbesticControl
+    description: >
+      % ΔF/F of baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Anxa-LRRK2 group, DLS) at 100 Hz.
+      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
+    fiber_photometry_table_region:
+      - dls_405
+    fiber_photometry_table_region_description: "DLS 405 nm isosbestic control channel (% ΔF/F, smoothed)."
+
+  # Calb-LRRK2 group (DMS) — baseline-corrected 470 nm
+  corrected_signal_calb:
+    name: FiberPhotometryResponseSeriesCorrectedSignal
+    description: >
+      Baseline-corrected GRAB-DA3m 470 nm fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
+      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
+      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
+    fiber_photometry_table_region:
+      - dms_470
+    fiber_photometry_table_region_description: "DMS 470 nm functional channel (baseline-corrected)."
+
+  # Calb-LRRK2 group (DMS) — baseline-corrected 405 nm isosbestic
+  corrected_isosbestic_calb:
+    name: FiberPhotometryResponseSeriesCorrectedIsosbesticControl
+    description: >
+      Baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
+      Processed by LRRK2_binning_and_processing.m: camera-trigger-aligned binning, then
+      sliding-window 8th-percentile baseline subtraction and division (window = 20 s).
+    fiber_photometry_table_region:
+      - dms_405
+    fiber_photometry_table_region_description: "DMS 405 nm isosbestic control channel (baseline-corrected)."
+
+  # Calb-LRRK2 group (DMS) — ΔF/F 470 nm
+  dff_calb:
+    name: FiberPhotometryResponseSeriesDfOverF
+    description: >
+      % ΔF/F of baseline-corrected GRAB-DA3m 470 nm fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
+      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
+    fiber_photometry_table_region:
+      - dms_470
+    fiber_photometry_table_region_description: "DMS 470 nm functional channel (% ΔF/F, smoothed)."
+
+  # Calb-LRRK2 group (DMS) — ΔF/F 405 nm isosbestic
+  dff_isosbestic_calb:
+    name: FiberPhotometryResponseSeriesDfOverFIsosbesticControl
+    description: >
+      % ΔF/F of baseline-corrected GRAB-DA3m 405 nm isosbestic fluorescence (Calb-LRRK2 group, DMS) at 100 Hz.
+      F0 = 8th percentile of the corrected trace. Smoothed with a 20-sample moving mean (~0.2 s).
+    fiber_photometry_table_region:
+      - dms_405
+    fiber_photometry_table_region_description: "DMS 405 nm isosbestic control channel (% ΔF/F, smoothed)."

--- a/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
+++ b/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
@@ -1,6 +1,6 @@
 from neuroconv import NWBConverter
 
-from .interfaces import Chen2026RawFiberPhotometryInterface
+from .interfaces import Chen2026ProcessedFiberPhotometryInterface, Chen2026RawFiberPhotometryInterface
 
 
 class Chen2026NWBConverter(NWBConverter):
@@ -8,12 +8,21 @@ class Chen2026NWBConverter(NWBConverter):
     NWB converter for Chen et al. 2026 (LRRK2 fiber photometry dataset).
 
     Raw interfaces (always present):
-      RawSignal          — 470 nm demultiplexed from ABF
-      IsosbesticControl  — 405 nm demultiplexed from ABF
+      RawSignal              — 470 nm demultiplexed from ABF
+      IsosbesticControl      — 405 nm demultiplexed from ABF
 
+    Processed interfaces (present when a *_data.mat file is provided):
+      CorrectedSignal        — baseline-corrected 470 nm (corrected470, 100 Hz)
+      CorrectedIsosbestic    — baseline-corrected 405 nm (corrected405, 100 Hz)
+      DfOverF                — % ΔF/F 470 nm, smoothed (dff470, 100 Hz)
+      DfOverFIsosbestic      — % ΔF/F 405 nm, smoothed (dff405, 100 Hz)
     """
 
     data_interface_classes = dict(
         RawSignal=Chen2026RawFiberPhotometryInterface,
         IsosbesticControl=Chen2026RawFiberPhotometryInterface,
+        CorrectedSignal=Chen2026ProcessedFiberPhotometryInterface,
+        CorrectedIsosbestic=Chen2026ProcessedFiberPhotometryInterface,
+        DfOverF=Chen2026ProcessedFiberPhotometryInterface,
+        DfOverFIsosbestic=Chen2026ProcessedFiberPhotometryInterface,
     )

--- a/src/dombeck_lab_to_nwb/chen2026/project_track.md
+++ b/src/dombeck_lab_to_nwb/chen2026/project_track.md
@@ -20,11 +20,12 @@
 - [x] `environment.yaml` — conda env, Python 3.13, neuroconv from GitHub main, ndx-fiber-photometry ≥0.2.3, ndx-ophys-devices ≥0.3.1
 - [x] Raw fiber photometry interface (`raw_fiber_photometry_interface.py`) — demultiplexes 470/405 nm from ABF using `fxn_gen` channel; module-level cache avoids double ABF read
 - [x] Processed fiber photometry interface (`processed_fiber_photometry_interface.py`) — reads `*_data.mat` (MATLAB v7.3 HDF5 via h5py reference chain); exposes corrected470, corrected405, dff470, dff405 at 100 Hz
-- [x] `Chen2026NWBConverter` — RawSignal + IsosbesticControl interfaces wired
-- [x] Stub test passes — Anxa group, animal 4007, session 2025-01-24-0002 ✓
-- [x] Stub test — Calb group (need to download a Calb ABF)
-- [x] ABF → animal ID mapping from `LRRK2-animal-list-meta.mat` (which ABF file corresponds to which animal?)
-- [x] `convert_all_sessions.py` — batch script for all 27 animals
+- [x] `Chen2026NWBConverter` — all 6 interfaces wired (RawSignal, IsosbesticControl, CorrectedSignal, CorrectedIsosbestic, DfOverF, DfOverFIsosbestic)
+- [x] Stub test passes — Anxa group, animal 4007, session 2025-08-13-0005 ✓
+- [x] Stub test — Calb group ✓ (all 12 Calb sessions pass)
+- [x] ABF → animal ID mapping from `LRRK2-animal-list-meta.mat` — decoded via `_data.mat` filename field
+- [x] `convert_all_sessions.py` — batch script for all 27 animals (parallel, 4 workers, per-animal error logs)
+- [x] Processed interfaces verified against `LRRK2_binning_and_processing.m` — column order, 100 Hz rate, and processing steps (baselineCorrect/df_f/movmean-20) confirmed
 - [ ] **Pending lab reply** — per-animal sex records, `stim_sequence` 'a' vs 'b' meaning, `initiation` channel meaning (Calb only), Calb DV fiber coordinate, Calb injection DV coordinate, publication DOI, experimenter name(s)
 
 ---
@@ -52,13 +53,15 @@ Genotypes per group: WT and LRRK2-G2019S (JAX:030961). Background: C57BL/6J. Age
 
 #### Processed fluorescence (from `*_data.mat` — 100 Hz, regular timestamps)
 
-- [ ] `FiberPhotometryResponseSeriesCorrectedSignal` — baseline-corrected 470 nm (`corrected470`)
-- [ ] `FiberPhotometryResponseSeriesCorrectedIsosbesticControl` — baseline-corrected 405 nm (`corrected405`)
-- [ ] `FiberPhotometryResponseSeriesDfOverF` — % ΔF/F 470 nm, smoothed (`dff470`)
-- [ ] `FiberPhotometryResponseSeriesDfOverFIsosbesticControl` — % ΔF/F 405 nm (`dff405`)
-- [ ] Processed interface implemented (`processed_fiber_photometry_interface.py`)
-- [ ] Wire processed interfaces back into `Chen2026NWBConverter` and `convert_session.py` (currently commented out)
-- [ ] Stub test processed interfaces
+- [x] `FiberPhotometryResponseSeriesCorrectedSignal` — baseline-corrected 470 nm (`corrected470`)
+- [x] `FiberPhotometryResponseSeriesCorrectedIsosbesticControl` — baseline-corrected 405 nm (`corrected405`)
+- [x] `FiberPhotometryResponseSeriesDfOverF` — % ΔF/F 470 nm, smoothed (`dff470`)
+- [x] `FiberPhotometryResponseSeriesDfOverFIsosbesticControl` — % ΔF/F 405 nm (`dff405`)
+- [x] Processed interface implemented (`processed_fiber_photometry_interface.py`)
+- [x] Wire processed interfaces back into `Chen2026NWBConverter` and `convert_session.py`
+- [x] Stub test processed interfaces — all 27 sessions pass (Anxa + Calb)
+- [x] Processed series routed to `nwbfile.processing["ophys"]` (override in `add_to_nwbfile`)
+- [ ] Open neuroconv PR: add `parent_container: Literal["acquisition", "processing/ophys"]` parameter to `BaseFiberPhotometryInterface.add_to_nwbfile` (workaround in place with TODO comment)
 
 ### Behavior (from `*_data.mat` — 100 Hz)
 


### PR DESCRIPTION
# Add processed fiber photometry interfaces for Chen et al. 2026

Review after #41 
Example file for reference: [sub-4007-anxa-gs_ses-2025-08-13-0005.nwb](https://drive.google.com/file/d/1dE5HjAS7MgaDQMX9fcPqCZbfjg4994Kg/view?usp=drive_link)
## Summary

Extends the Chen et al. 2026 (LRRK2) conversion to include four processed fiber photometry series from the per-animal *_data.mat files, alongside the existing raw ABF interfaces.

- New interface `Chen2026ProcessedFiberPhotometryInterface` reads the MATLAB v7.3 HDF5 *_data.mat file via h5py (MCOS reference chain). It exposes four 100 Hz streams: corrected470, corrected405, dff470, dff405 — all produced by LRRK2_binning_and_processing.m (sliding 8th-percentile baseline correction, then % ΔF/F with 20-sample moving mean).
- `Chen2026NWBConverter` updated to register all six interfaces: the two raw ABF interfaces (RawSignal, IsosbesticControl) and the four new processed ones (CorrectedSignal, CorrectedIsosbestic, DfOverF, DfOverFIsosbestic).
- `convert_session.py` updated with a mat_file parameter; processed interfaces are added conditionally when a *_data.mat path is provided.
- `fiber_photometry.yaml` extended with eight new response-series entries (four per group: Anxa/DLS and Calb/DMS), with descriptions referencing the exact processing steps from the MATLAB script.
- Processed series are written to nwbfile.processing["ophys"] rather than acquisition. This is done via an add_to_nwbfile override (move from acquisition after super() call) with a TODO to remove it once neuroconv's BaseFiberPhotometryInterface gains a parent_container parameter.

## Testing
All 27 sessions stub-tested (15 Anxa + 12 Calb), all passing with all six interfaces.