### PR TITLE
Add processed behavior ogen for LRRK2 dataset

### DIFF
--- a/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
+++ b/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
@@ -132,6 +132,23 @@ Note: `stim_sequence` is a MATLAB categorical — pymatreader cannot parse it. U
 
 Fiber implant DV depth = ferrule length (Doric convention), referenced from dura surface.
 
+**Optogenetics surgery (Anxa1+ group):**
+- SNc craniotomy: −3.20 mm caudal, +1.60 mm lateral from bregma (right hemisphere)
+- ChRmine injection: 4 depths (−3.8, −4.1, −4.4, −4.7 mm ventral from dura), 0.1 µL/depth = 0.4 µL total
+- Opto fiber implanted via same craniotomy just above SNc (tip at ~4.0 mm from dura)
+- Striatum GRAB-DA3m injection (DLS): +0.5 mm caudal, +1.8 mm lateral; −1.9 mm from dura
+
+**Optogenetics surgery (Calb1+ group):**
+- Same SNc craniotomy as Anxa1+ (−3.20 mm caudal, +1.60 mm lateral)
+- ChRmine injection: 1 depth only (−4.3 mm from dura) to prevent VTA/thalamus spillover
+- Striatum GRAB-DA3m injection (DMS): +0.5 mm caudal, +1.4 mm lateral; −1.9 mm from dura
+
+**Confirmed stimulation parameters:**
+- Pulse shape: 8 ms on / 8 ms off (period = 16 ms, ~31 pulses per 500 ms train)
+- Powers: 0.1, 0.5, 1.0, 4.0 mW at cannula tip (pseudorandom order, 8 reps each)
+- Intertrain interval: ≥20 s; each recording session = 20 minutes
+- TTL in `_data.mat` is HIGH for the full 500 ms train duration (not per-pulse)
+
 ---
 
 ### Comparison with Existing Pipelines

--- a/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
+++ b/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
@@ -4,7 +4,7 @@
 
 **Manuscript:** "Leucine-rich repeat kinase 2 impairs the release sites of Parkinson's disease vulnerable dopamine axons", Chen, He et al. (in preparation)
 **Analysis code:** https://github.com/DombeckLab/lrrk2_photometry_analysis (Zenodo: 10.5281/zenodo.20244434)
-**Status:** All fiber photometry interfaces implemented and stub-tested (27/27 sessions pass). Full conversion run pending.
+**Status:** All interfaces implemented; 27/27 sessions converted successfully.
 **Detailed notes:** see `lrrk2_investigation.md`
 
 ---
@@ -143,11 +143,20 @@ Fiber implant DV depth = ferrule length (Doric convention), referenced from dura
 - ChRmine injection: 1 depth only (−4.3 mm from dura) to prevent VTA/thalamus spillover
 - Striatum GRAB-DA3m injection (DMS): +0.5 mm caudal, +1.4 mm lateral; −1.9 mm from dura
 
-**Confirmed stimulation parameters:**
-- Pulse shape: 8 ms on / 8 ms off (period = 16 ms, ~31 pulses per 500 ms train)
-- Powers: 0.1, 0.5, 1.0, 4.0 mW at cannula tip (pseudorandom order, 8 reps each)
+**Confirmed stimulation parameters (measured from raw ABF, channel `opto_TTL`, 2000 Hz):**
+
+Each session contains **64 trains total** (8 power levels × 8 repetitions). The two halves of the session use different pulse protocols:
+
+| Epoch range | Amplitude | Pulse ON | Pulse OFF | Period | Pulses/train | Train duration |
+|-------------|-----------|----------|-----------|--------|--------------|----------------|
+| 0 – 31 (first half) | ~1.2 V | 9 ms | 1 ms | 10 ms (100 Hz) | 32 | ~320 ms |
+| 32 – 63 (second half) | ~0.05 V | 8 ms | 8 ms | 16 ms (62.5 Hz) | 32 | ~505 ms |
+
+The manuscript states "8 ms on / 8 ms off" (16 ms period, ~31 pulses), which describes only the second half. Both halves have exactly 32 pulses per train. The first-half trains fire at 100 Hz (one pulse per camera frame). Per-epoch values are stored in `OptogeneticEpochsTable` columns — see `convert_session.py`.
+
+- Powers: 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0 mW at cannula tip (pseudorandom order, 8 reps each)
 - Intertrain interval: ≥20 s; each recording session = 20 minutes
-- TTL in `_data.mat` is HIGH for the full 500 ms train duration (not per-pulse)
+- TTL in `_data.mat` is HIGH for the full train duration (not per-pulse)
 
 ---
 
@@ -227,10 +236,11 @@ The trigger spacing is nominally 10 ms (100 Hz) with ±0.5 ms quantization noise
 
 #### Optogenetic stimulation epochs
 
-- **Source:** `TTL` column in `_data.mat` (uint8, 0 or 1, 100 Hz), which encodes whether the 635 nm LED was on during each camera-trigger bin.
-- **Epoch extraction:** contiguous runs of `TTL = 1` are detected. At 10 ms/sample, the 8 ms on / 8 ms off pulse pattern within a 500 ms train appears as a single block of ~33 consecutive samples (~330 ms) because the 8 ms on-phase dominates each 10 ms bin. Each extracted epoch row corresponds to one 500 ms pulse train.
+- **Source:** `TTL` column in `_data.mat` (uint8, 0 or 1, 100 Hz). The MATLAB script binarizes via `any(opto > 0.05 V)` per 10 ms camera bin.
+- **TTL fragmentation problem:** first-half trains (~1.2 V, 10 ms period) appear as clean single blobs in the mat TTL. Second-half trains (~0.05 V, barely above the 0.05 V threshold) fragment into 2–10 blobs per train because the low-amplitude ABF pulses alias unevenly across 10 ms camera bins. Naively detected blobs = 122 for these sessions; correct train count = 64.
+- **Merge fix:** `_extract_epochs()` merges blobs whose gap is < 1 s into a single epoch. Inter-train intervals are ≥20 s, so the 1 s threshold is unambiguous. All 27 sessions yield exactly 64 epochs after merging.
 - **Epoch times:** `start_time = camera_trigger_times[first_high_sample]`, `stop_time = camera_trigger_times[first_low_sample_after_epoch]`. These are in the ABF clock, aligned with all other signals.
-- **Note:** stimulation begins at ~30–50 s into the session (well after the ~21 s camera-start offset), so all 122 epochs fall within the processed FP time range.
+- **Note:** stimulation begins at ~30–50 s into the session (well after the ~21 s camera-start offset), so all 64 epochs fall within the processed FP time range.
 
 #### Summary: what defines `t = 0` for this dataset
 
@@ -253,9 +263,8 @@ A TODO comment in the interface marks this for removal once a neuroconv PR adds 
 
 ### Open Questions (needs lab confirmation)
 
-1. **`stim_sequence` 'a' vs 'b'**: 18 animals have 'a', 9 have 'b', mixed across groups and genotypes. Likely encodes the pseudorandom power order (0.1/0.5/1.0/4.0 mW). Needed to set per-epoch `power_in_mW` in `OptogeneticEpochsTable`.
+1. **`stim_sequence` 'a' vs 'b'**: resolved — encodes the pseudorandom power order. Per-epoch `power_in_mW` is now populated in `OptogeneticEpochsTable` for all 27 sessions from `LRRK2.xlsx`.
 2. **`initiation` channel**: What does this signal represent? Store in NWB?
 3. **Per-animal sex records** — manuscript says both sexes used but no individual records confirmed
 4. **Publication DOI** — manuscript not yet published; Zenodo: 10.5281/zenodo.20244434
 5. **Experimenter names** — confirm which authors collected the photometry data
-6. **`power_in_mW` per epoch** — currently NaN in OptogeneticEpochsTable; resolve via stim_sequence 'a'/'b' mapping with lab

--- a/src/dombeck_lab_to_nwb/chen2026/convert_all_sessions.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_all_sessions.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import traceback
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime, timezone
 from pathlib import Path
 
+import pandas as pd
 from tqdm import tqdm
 
 from dombeck_lab_to_nwb.chen2026.convert_session import convert_session
@@ -23,9 +25,52 @@ from dombeck_lab_to_nwb.chen2026.convert_session import convert_session
 # ---------------------------------------------------------------------------
 DATA_DIR = Path("/Users/weian/lrrk2_data")
 NWB_OUTPUT_DIR = Path("/Users/weian/lrrk2_data/nwb-output")
+SUBJECT_METADATA_XLSX = Path("/Users/weian/lrrk2_data/metadata-LRRK2-chen2026.xlsx")
+STIM_SEQUENCE_XLSX = Path("/Users/weian/lrrk2_data/stimulation sequence LRRK2.xlsx")
 STUB_TEST = False
 MAX_WORKERS = 4  # number of parallel conversion processes
 # ---------------------------------------------------------------------------
+
+# Code → power (mW) mapping from stimulation sequence LRRK2.xlsx
+_CODE_TO_POWER: dict[str, float] = {
+    "a": 0.1,
+    "b": 0.25,
+    "c": 0.5,
+    "d": 1.0,
+    "e": 1.5,
+    "f": 2.0,
+    "g": 3.0,
+    "h": 4.0,
+}
+
+
+def _load_stim_sequences(xlsx_path: Path) -> dict[str, list[float]]:
+    """Return {'a': [...64 powers...], 'b': [...64 powers...]} from the stim sequence xlsx."""
+    df = pd.read_excel(xlsx_path, header=None)
+    sequences: dict[str, list[float]] = {}
+    for _, row in df.iterrows():
+        label = str(row.iloc[0]).strip()
+        if label.lower().startswith("sequence a"):
+            codes = [str(v).strip("' ") for v in row.iloc[1:] if pd.notna(v)]
+            sequences["a"] = [_CODE_TO_POWER[c] for c in codes]
+        elif label.lower().startswith("sequence b"):
+            codes = [str(v).strip("' ") for v in row.iloc[1:] if pd.notna(v)]
+            sequences["b"] = [_CODE_TO_POWER[c] for c in codes]
+    return sequences
+
+
+def _load_subject_metadata(xlsx_path: Path) -> dict[str, dict]:
+    """Return a dict keyed by abf filename → {sex, date_of_birth, stim_sequence}."""
+    df = pd.read_excel(xlsx_path)
+    lookup: dict[str, dict] = {}
+    for _, row in df.iterrows():
+        filename = str(row["filename"]).strip("'")
+        sex = str(row["sex"]).strip().upper()
+        dob: datetime = pd.to_datetime(row["DOB"]).to_pydatetime().replace(tzinfo=timezone.utc)
+        stim_seq = str(row["stim_sequence"]).strip().lower()
+        lookup[filename] = {"sex": sex, "date_of_birth": dob, "stim_sequence": stim_seq}
+    return lookup
+
 
 # Complete animal × session table derived from LRRK2-animal-list-meta.mat
 # and the filename column of each *_data.mat file.
@@ -63,7 +108,14 @@ SESSIONS = [
 ]
 
 
-def _session_to_nwb(session: dict, data_dir: Path, nwb_output_dir: Path, stub_test: bool) -> str:
+def _session_to_nwb(
+    session: dict,
+    data_dir: Path,
+    nwb_output_dir: Path,
+    stub_test: bool,
+    subject_lookup: dict[str, dict],
+    stim_sequences: dict[str, list[float]],
+) -> str:
     """Convert one session; return a status string."""
     animal_id = session["animal_id"]
     group = session["group"]
@@ -73,6 +125,12 @@ def _session_to_nwb(session: dict, data_dir: Path, nwb_output_dir: Path, stub_te
     abf_file = data_dir / group_dir / session["abf_filename"]
     mat_file = data_dir / group_dir / animal_id / f"{animal_id}_data.mat"
 
+    subject_info = subject_lookup.get(session["abf_filename"], {})
+    sex = subject_info.get("sex", "U")
+    date_of_birth = subject_info.get("date_of_birth")
+    stim_seq_key = subject_info.get("stim_sequence")
+    power_sequence = stim_sequences.get(stim_seq_key) if stim_seq_key else None
+
     convert_session(
         file_path=abf_file,
         mat_file=mat_file,
@@ -80,15 +138,25 @@ def _session_to_nwb(session: dict, data_dir: Path, nwb_output_dir: Path, stub_te
         subject_id=animal_id,
         group=group,
         genotype=genotype,
+        sex=sex,
+        date_of_birth=date_of_birth,
+        power_sequence=power_sequence,
         stub_test=stub_test,
     )
     return f"OK  {animal_id}"
 
 
-def _safe_session_to_nwb(session: dict, data_dir: Path, nwb_output_dir: Path, stub_test: bool) -> str:
+def _safe_session_to_nwb(
+    session: dict,
+    data_dir: Path,
+    nwb_output_dir: Path,
+    stub_test: bool,
+    subject_lookup: dict[str, dict],
+    stim_sequences: dict[str, list[float]],
+) -> str:
     """Wrapper that catches exceptions and writes an error log instead of crashing the pool."""
     try:
-        return _session_to_nwb(session, data_dir, nwb_output_dir, stub_test)
+        return _session_to_nwb(session, data_dir, nwb_output_dir, stub_test, subject_lookup, stim_sequences)
     except Exception:
         animal_id = session["animal_id"]
         error_path = nwb_output_dir / f"error_{animal_id}.txt"
@@ -100,15 +168,22 @@ def _safe_session_to_nwb(session: dict, data_dir: Path, nwb_output_dir: Path, st
 def dataset_to_nwb(
     data_dir: Path = DATA_DIR,
     nwb_output_dir: Path = NWB_OUTPUT_DIR,
+    subject_metadata_xlsx: Path = SUBJECT_METADATA_XLSX,
+    stim_sequence_xlsx: Path = STIM_SEQUENCE_XLSX,
     stub_test: bool = STUB_TEST,
     max_workers: int = MAX_WORKERS,
 ) -> None:
     nwb_output_dir.mkdir(parents=True, exist_ok=True)
 
+    subject_lookup = _load_subject_metadata(subject_metadata_xlsx)
+    stim_sequences = _load_stim_sequences(stim_sequence_xlsx)
+
     futures = {}
     with ProcessPoolExecutor(max_workers=max_workers) as pool:
         for session in SESSIONS:
-            future = pool.submit(_safe_session_to_nwb, session, data_dir, nwb_output_dir, stub_test)
+            future = pool.submit(
+                _safe_session_to_nwb, session, data_dir, nwb_output_dir, stub_test, subject_lookup, stim_sequences
+            )
             futures[future] = session["animal_id"]
 
         results = []

--- a/src/dombeck_lab_to_nwb/chen2026/convert_session.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_session.py
@@ -6,6 +6,7 @@ bottom of this file, then run::
     python convert_session.py
 """
 
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -47,6 +48,9 @@ def convert_session(
     subject_id: str,
     group: Literal["Anxa", "Calb"] = "Anxa",
     genotype: Literal["WT", "GS"] = "WT",
+    sex: str = "U",
+    date_of_birth: datetime | None = None,
+    power_sequence: list[float] | None = None,
     mat_file: str | Path | None = None,
     stub_test: bool = False,
 ) -> None:
@@ -64,6 +68,13 @@ def convert_session(
         Experimental group: "Anxa" or "Calb".
     genotype : Literal["WT", "GS"], default "WT"
         Genotype: "WT" or "GS" (LRRK2-G2019S).
+    sex : str, default "U"
+        Subject sex: "M", "F", or "U".
+    date_of_birth : datetime | None
+        Subject date of birth (timezone-aware). Written as ``Subject.date_of_birth``.
+    power_sequence : list[float] | None
+        Per-epoch stimulation powers in mW, one entry per TTL epoch in the session.
+        If None the power field in the epochs table is left as NaN.
     mat_file : str | Path | None
         Path to the *_data.mat file. When provided the four processed
         fluorescence series (corrected470/405, dff470/405) are also written.
@@ -156,6 +167,9 @@ def convert_session(
     subject_meta = general_metadata["Subject"].copy()
     subject_meta["subject_id"] = subject_id
     subject_meta["genotype"] = genotype_label
+    subject_meta["sex"] = sex
+    if date_of_birth is not None:
+        subject_meta["date_of_birth"] = date_of_birth
     subject_meta["description"] = general_metadata["SubjectDescriptions"][group]
     metadata["Subject"] = subject_meta
 
@@ -171,17 +185,18 @@ def convert_session(
                 "DfOverF": {"stub_test": stub_test},
                 "DfOverFIsosbestic": {"stub_test": stub_test},
                 "Behavior": {"stub_test": stub_test},
-                # Confirmed stim parameters (Chen et al. 2026, Methods):
-                # 8 ms on / 8 ms off pulses for 500 ms trains (period=16 ms, ~31 pulses/train).
-                # power_in_mW varies per epoch (0.1/0.5/1.0/4.0 mW pseudorandom); left as NaN
-                # until per-epoch power can be extracted from stim_sequence data.
+                # Stim parameters measured from raw ABF (2000 Hz, channel 2 = opto_TTL).
+                # Epochs 1–32 (high amplitude): 9 ms ON / 1 ms OFF, 10 ms period, ~320 ms train.
+                # Epochs 33–64 (low amplitude):  8 ms ON / 8 ms OFF, 16 ms period, ~505 ms train.
+                # Both halves have 32 pulses per train.
                 "Optogenetics": {
                     "stub_test": stub_test,
-                    "pulse_length_in_ms": 8.0,
-                    "period_in_ms": 16.0,
-                    "number_pulses_per_pulse_train": 31,
-                    "number_trains": 1,  # each epoch row = one 500ms pulse train
+                    "pulse_length_in_ms": [9.0] * 32 + [8.0] * 32,
+                    "period_in_ms": [10.0] * 32 + [16.0] * 32,
+                    "number_pulses_per_pulse_train": [32] * 64,
+                    "number_trains": 1,  # each epoch row = one pulse train
                     "intertrain_interval_in_ms": 20000.0,
+                    "power_in_mW": power_sequence if power_sequence is not None else [float("nan")] * 64,
                 },
             }
         )
@@ -196,6 +211,8 @@ def convert_session(
 
 
 if __name__ == "__main__":
+    from datetime import timezone
+
     # --- Edit these paths and parameters before running ---
     abf_file = Path("/Users/weian/lrrk2_data/Anxa-LRRK2/2025_08_13_0005.abf")
     mat_file = Path("/Users/weian/lrrk2_data/Anxa-LRRK2/4007/4007_data.mat")  # set to None to skip processed
@@ -204,6 +221,76 @@ if __name__ == "__main__":
     group = "Anxa"  # "Anxa" or "Calb"
     genotype = "GS"  # "WT" or "GS"
     stub_test = False
+    # Per-animal metadata from metadata-LRRK2-chen2026.xlsx
+    subject_sex = "M"
+    subject_dob = datetime(2025, 1, 13, tzinfo=timezone.utc)
+    # Power sequence A from stimulation sequence LRRK2.xlsx (stim_sequence = 'a')
+    subject_power_sequence = [
+        2.0,
+        2.0,
+        3.0,
+        3.0,
+        0.25,
+        0.25,
+        1.5,
+        1.5,
+        2.0,
+        2.0,
+        3.0,
+        3.0,
+        0.25,
+        0.25,
+        1.5,
+        1.5,
+        2.0,
+        2.0,
+        3.0,
+        3.0,
+        0.25,
+        0.25,
+        1.5,
+        1.5,
+        2.0,
+        2.0,
+        3.0,
+        3.0,
+        0.25,
+        0.25,
+        1.5,
+        1.5,
+        1.0,
+        1.0,
+        0.1,
+        0.1,
+        0.5,
+        0.5,
+        4.0,
+        4.0,
+        1.0,
+        1.0,
+        0.1,
+        0.1,
+        0.5,
+        0.5,
+        4.0,
+        4.0,
+        1.0,
+        1.0,
+        0.1,
+        0.1,
+        0.5,
+        0.5,
+        4.0,
+        4.0,
+        1.0,
+        1.0,
+        0.1,
+        0.1,
+        0.5,
+        0.5,
+        4.0,
+        4.0,
+    ]
     # ------------------------------------------------------
 
     convert_session(
@@ -213,5 +300,8 @@ if __name__ == "__main__":
         subject_id=animal_id,
         group=group,
         genotype=genotype,
+        sex=subject_sex,
+        date_of_birth=subject_dob,
+        power_sequence=subject_power_sequence,
         stub_test=stub_test,
     )

--- a/src/dombeck_lab_to_nwb/chen2026/convert_session.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_session.py
@@ -99,7 +99,7 @@ def convert_session(
         },
     }
 
-    # Processed interfaces — present only when mat_file is provided
+    # Processed + optogenetics interfaces — present only when mat_file is provided
     if mat_file is not None:
         mat_file = str(mat_file)
         source_data.update(
@@ -124,6 +124,12 @@ def convert_session(
                     "stream_names": ["dff405"],
                     "metadata_key": metadata_keys["DfOverFIsosbestic"],
                 },
+                "Behavior": {
+                    "file_path": mat_file,
+                },
+                "Optogenetics": {
+                    "file_path": mat_file,
+                },
             }
         )
 
@@ -132,6 +138,10 @@ def convert_session(
 
     fp_metadata = load_dict_from_file(METADATA_DIR / "fiber_photometry.yaml")
     metadata = dict_deep_update(metadata, fp_metadata)
+
+    if mat_file is not None:
+        opto_metadata = load_dict_from_file(METADATA_DIR / "optogenetics.yaml")
+        metadata = dict_deep_update(metadata, opto_metadata)
 
     # NWBFile: static fields from YAML + dynamic per-session fields
     general_metadata = load_dict_from_file(METADATA_DIR / "general_metadata.yaml")
@@ -160,6 +170,19 @@ def convert_session(
                 "CorrectedIsosbestic": {"stub_test": stub_test},
                 "DfOverF": {"stub_test": stub_test},
                 "DfOverFIsosbestic": {"stub_test": stub_test},
+                "Behavior": {"stub_test": stub_test},
+                # Confirmed stim parameters (Chen et al. 2026, Methods):
+                # 8 ms on / 8 ms off pulses for 500 ms trains (period=16 ms, ~31 pulses/train).
+                # power_in_mW varies per epoch (0.1/0.5/1.0/4.0 mW pseudorandom); left as NaN
+                # until per-epoch power can be extracted from stim_sequence data.
+                "Optogenetics": {
+                    "stub_test": stub_test,
+                    "pulse_length_in_ms": 8.0,
+                    "period_in_ms": 16.0,
+                    "number_pulses_per_pulse_train": 31,
+                    "number_trains": 1,  # each epoch row = one 500ms pulse train
+                    "intertrain_interval_in_ms": 20000.0,
+                },
             }
         )
 

--- a/src/dombeck_lab_to_nwb/chen2026/convert_session.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_session.py
@@ -41,6 +41,67 @@ GENOTYPE_LABELS = {
     "GS": "LRRK2-G2019S",
 }
 
+_OPTO_THRESHOLD_V = 0.01  # V — catches both high (~1.2 V) and low (~0.05 V) amplitude trains
+
+
+def _detect_opto_pulse_params(
+    abf_file: str | Path,
+) -> tuple[list[float], list[float], list[int]]:
+    """Detect per-epoch pulse parameters from the raw ABF opto_TTL channel.
+
+    Returns (pulse_length_in_ms, period_in_ms, number_pulses_per_pulse_train),
+    one value per detected stimulation train. Trains are separated by gaps > 1 s
+    between consecutive pulse onsets; intra-train inter-onset intervals are used
+    to compute the period.
+    """
+    import math
+
+    import numpy as np
+    import pyabf
+
+    abf = pyabf.ABF(str(abf_file), loadData=True)
+    channel_names = [abf.adcNames[i].strip() for i in range(abf.channelCount)]
+
+    opto_idx = channel_names.index("opto_TTL")
+    opto = abf.data[opto_idx]
+    sr = float(abf.dataRate)
+
+    above = opto > _OPTO_THRESHOLD_V
+    diff = np.diff(above.astype(np.int8))
+    rising = np.where(diff == 1)[0]
+    falling = np.where(diff == -1)[0]
+
+    if len(falling) and len(rising) and falling[0] < rising[0]:
+        falling = falling[1:]
+    n = min(len(rising), len(falling))
+    rising = rising[:n]
+    falling = falling[:n]
+
+    if n == 0:
+        return [], [], []
+
+    onsets = rising / sr
+    durations = (falling - rising) / sr
+
+    # Split into trains: gap > 1 s between consecutive pulse onsets
+    inter_onset = np.diff(onsets)
+    breaks = np.where(inter_onset > 1.0)[0]
+    starts = np.concatenate([[0], breaks + 1])
+    ends = np.concatenate([breaks + 1, [n]])
+
+    pulse_length_ms: list[float] = []
+    period_ms: list[float] = []
+    n_pulses: list[int] = []
+
+    for s, e in zip(starts, ends):
+        epoch_onsets = onsets[s:e]
+        epoch_durations = durations[s:e]
+        pulse_length_ms.append(round(float(np.mean(epoch_durations)) * 1000, 3))
+        period_ms.append(round(float(np.mean(np.diff(epoch_onsets))) * 1000, 3) if len(epoch_onsets) > 1 else math.nan)
+        n_pulses.append(int(e - s))
+
+    return pulse_length_ms, period_ms, n_pulses
+
 
 def convert_session(
     file_path: str | Path,
@@ -178,6 +239,8 @@ def convert_session(
         "IsosbesticControl": {"stub_test": stub_test},
     }
     if mat_file is not None:
+        pulse_length_ms, period_ms, n_pulses = _detect_opto_pulse_params(file_path)
+        n_epochs = len(pulse_length_ms)
         conversion_options.update(
             {
                 "CorrectedSignal": {"stub_test": stub_test},
@@ -185,18 +248,14 @@ def convert_session(
                 "DfOverF": {"stub_test": stub_test},
                 "DfOverFIsosbestic": {"stub_test": stub_test},
                 "Behavior": {"stub_test": stub_test},
-                # Stim parameters measured from raw ABF (2000 Hz, channel 2 = opto_TTL).
-                # Epochs 1–32 (high amplitude): 9 ms ON / 1 ms OFF, 10 ms period, ~320 ms train.
-                # Epochs 33–64 (low amplitude):  8 ms ON / 8 ms OFF, 16 ms period, ~505 ms train.
-                # Both halves have 32 pulses per train.
                 "Optogenetics": {
                     "stub_test": stub_test,
-                    "pulse_length_in_ms": [9.0] * 32 + [8.0] * 32,
-                    "period_in_ms": [10.0] * 32 + [16.0] * 32,
-                    "number_pulses_per_pulse_train": [32] * 64,
-                    "number_trains": 1,  # each epoch row = one pulse train
+                    "pulse_length_in_ms": pulse_length_ms,
+                    "period_in_ms": period_ms,
+                    "number_pulses_per_pulse_train": n_pulses,
+                    "number_trains": 1,
                     "intertrain_interval_in_ms": 20000.0,
-                    "power_in_mW": power_sequence if power_sequence is not None else [float("nan")] * 64,
+                    "power_in_mW": power_sequence if power_sequence is not None else [float("nan")] * n_epochs,
                 },
             }
         )

--- a/src/dombeck_lab_to_nwb/chen2026/convert_session.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_session.py
@@ -96,8 +96,8 @@ def _detect_opto_pulse_params(
     for s, e in zip(starts, ends):
         epoch_onsets = onsets[s:e]
         epoch_durations = durations[s:e]
-        pulse_length_ms.append(round(float(np.mean(epoch_durations)) * 1000, 3))
-        period_ms.append(round(float(np.mean(np.diff(epoch_onsets))) * 1000, 3) if len(epoch_onsets) > 1 else math.nan)
+        pulse_length_ms.append(round(float(np.mean(epoch_durations)) * 1000))
+        period_ms.append(round(float(np.mean(np.diff(epoch_onsets))) * 1000) if len(epoch_onsets) > 1 else math.nan)
         n_pulses.append(int(e - s))
 
     return pulse_length_ms, period_ms, n_pulses

--- a/src/dombeck_lab_to_nwb/chen2026/convert_session.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_session.py
@@ -96,8 +96,8 @@ def _detect_opto_pulse_params(
     for s, e in zip(starts, ends):
         epoch_onsets = onsets[s:e]
         epoch_durations = durations[s:e]
-        pulse_length_ms.append(round(float(np.mean(epoch_durations)) * 1000))
-        period_ms.append(round(float(np.mean(np.diff(epoch_onsets))) * 1000) if len(epoch_onsets) > 1 else math.nan)
+        pulse_length_ms.append(round(float(np.mean(epoch_durations)) * 1000, 0))
+        period_ms.append(round(float(np.mean(np.diff(epoch_onsets))) * 1000, 0) if len(epoch_onsets) > 1 else math.nan)
         n_pulses.append(int(e - s))
 
     return pulse_length_ms, period_ms, n_pulses

--- a/src/dombeck_lab_to_nwb/chen2026/environment.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/environment.yaml
@@ -19,3 +19,4 @@ dependencies:
     - pyyaml>=6.0
     - numpy>=1.26
     - tqdm
+    - openpyxl>=3.1

--- a/src/dombeck_lab_to_nwb/chen2026/environment.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/environment.yaml
@@ -9,6 +9,7 @@ dependencies:
     - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git
     - ndx-fiber-photometry>=0.2.3
     - ndx-ophys-devices>=0.3.1
+    - ndx-optogenetics>=0.4.0
     - pynwb
     - pyabf>=2.3.8
     - pymatreader>=0.5.0

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/__init__.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/__init__.py
@@ -1,7 +1,11 @@
+from .behavior_interface import Chen2026BehaviorInterface
+from .optogenetics_interface import Chen2026OptogeneticsInterface
 from .processed_fiber_photometry_interface import Chen2026ProcessedFiberPhotometryInterface
 from .raw_fiber_photometry_interface import Chen2026RawFiberPhotometryInterface
 
 __all__ = [
     "Chen2026RawFiberPhotometryInterface",
     "Chen2026ProcessedFiberPhotometryInterface",
+    "Chen2026OptogeneticsInterface",
+    "Chen2026BehaviorInterface",
 ]

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/behavior_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/behavior_interface.py
@@ -1,0 +1,79 @@
+"""Behavior interface for Chen et al. 2026 (LRRK2 dataset).
+
+Reads treadmill velocity and acceleration from the per-animal *_data.mat file
+(100 Hz, camera-trigger-aligned binning) and writes them to processing/behavior
+as a BehavioralTimeSeries containing two TimeSeries:
+
+  - treadmill_velocity     (m/s)
+  - treadmill_acceleration (m/s²)
+"""
+
+from pathlib import Path
+
+from neuroconv.basedatainterface import BaseDataInterface
+from neuroconv.tools import get_module
+from pynwb import NWBFile, TimeSeries
+from pynwb.behavior import BehavioralTimeSeries
+
+from .processed_fiber_photometry_interface import _read_mat
+
+
+class Chen2026BehaviorInterface(BaseDataInterface):
+    """Behavior interface for Chen et al. 2026 (LRRK2 dataset).
+
+    Reads treadmill velocity (m/s) and acceleration (m/s²) from the 100 Hz
+    binned columns in the per-animal *_data.mat file and writes them to
+    processing/behavior as a BehavioralTimeSeries.
+    """
+
+    display_name = "Chen2026 Behavior (*_data.mat velocity/acceleration)"
+    associated_suffixes = (".mat",)
+    info = "Interface for treadmill velocity and acceleration from *_data.mat."
+
+    def __init__(self, *, file_path: str | Path, verbose: bool = False):
+        super().__init__(file_path=str(file_path), verbose=verbose)
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict | None = None,
+        stub_test: bool = False,
+    ) -> None:
+        mat = _read_mat(self.source_data["file_path"])
+
+        velocity = mat["velocity"]
+        acceleration = mat["acceleration"]
+        timestamps = mat["camera_trigger_times"]
+
+        if stub_test:
+            velocity = velocity[:100]
+            acceleration = acceleration[:100]
+            timestamps = timestamps[:100]
+
+        velocity_ts = TimeSeries(
+            name="treadmill_velocity",
+            description=(
+                "Treadmill velocity at 100 Hz (camera-trigger-aligned binning). "
+                "Derived from rotary encoder voltage using calibration factor 1.3532 m/s per V. "
+                "Positive values indicate forward locomotion. "
+            ),
+            data=velocity,
+            unit="m/s",
+            timestamps=timestamps,
+        )
+
+        acceleration_ts = TimeSeries(
+            name="treadmill_acceleration",
+            description="Treadmill acceleration at 100 Hz (camera-trigger-aligned binning).",
+            data=acceleration,
+            unit="m/s^2",
+            timestamps=timestamps,
+        )
+
+        behavioral_ts = BehavioralTimeSeries(
+            name="BehavioralTimeSeries",
+            time_series=[velocity_ts, acceleration_ts],
+        )
+
+        behavior_module = get_module(nwbfile, name="behavior", description="Processed behavioral data.")
+        behavior_module.add(behavioral_ts)

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/optogenetics_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/optogenetics_interface.py
@@ -1,0 +1,269 @@
+"""Optogenetics interface for Chen et al. 2026 (LRRK2 dataset).
+
+Reads the binary TTL column from the per-animal *_data.mat file (100 Hz,
+camera-trigger-aligned binning) and writes:
+
+  - ``OptogeneticExperimentMetadata`` (lab_meta_data): LED, fiber, virus, injection, effector
+  - ``OptogeneticEpochsTable`` (intervals): one row per contiguous TTL-on epoch
+
+Confirmed stim parameters (from manuscript):
+  - pulse_length_in_ms = 8.0 ms, period_in_ms = 16.0 ms (8 ms on / 8 ms off)
+  - ~31 pulses per 500 ms train; trains spaced ≥ 20 s apart; 8 reps per power level
+  - Powers (pseudorandom order): 0.1, 0.5, 1.0, 4.0 mW — varies per epoch; leave as NaN
+    until per-epoch power can be read from stim_sequence data.
+"""
+
+import math
+from pathlib import Path
+
+import numpy as np
+from neuroconv.basedatainterface import BaseDataInterface
+from pynwb import NWBFile
+
+from .processed_fiber_photometry_interface import _read_mat
+
+
+class Chen2026OptogeneticsInterface(BaseDataInterface):
+    """Optogenetics interface for Chen et al. 2026 (LRRK2 dataset).
+
+    Reads the 100 Hz binary TTL column from the per-animal *_data.mat file and
+    writes an ``OptogeneticEpochsTable`` (one row per contiguous stimulation epoch)
+    plus full ``OptogeneticExperimentMetadata`` (LED, fiber, virus, effector).
+    """
+
+    display_name = "Chen2026 Optogenetics (*_data.mat TTL)"
+    associated_suffixes = (".mat",)
+    info = "Interface for optogenetic stimulation epochs from the TTL column of *_data.mat."
+
+    def __init__(self, *, file_path: str | Path, verbose: bool = False):
+        super().__init__(file_path=str(file_path), verbose=verbose)
+
+    def _get_ttl(self) -> np.ndarray:
+        return _read_mat(self.source_data["file_path"])["TTL"]
+
+    @staticmethod
+    def _extract_epochs(ttl: np.ndarray, trigger_times: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Return (start_times_s, stop_times_s) for each contiguous block of TTL=1.
+
+        Uses actual camera trigger timestamps so epoch times are aligned to the
+        ABF recording clock (same reference as the raw FP acquisition).
+        """
+        padded = np.concatenate([[0], ttl.astype(np.int8), [0]])
+        diff = np.diff(padded)
+        # diff[k]==1  → ttl transitions 0→1 at index k  → trigger_times[k]
+        # diff[k]==-1 → ttl transitions 1→0 after index k-1; stop = trigger_times[k]
+        #   (or last trigger + 1 sample if k == len(trigger_times))
+        start_indices = np.where(diff == 1)[0]
+        stop_indices = np.where(diff == -1)[0]
+        n = len(trigger_times)
+        dt = trigger_times[-1] - trigger_times[-2] if n >= 2 else 0.01
+        start_times = trigger_times[start_indices]
+        stop_times = np.array([trigger_times[k] if k < n else trigger_times[-1] + dt for k in stop_indices])
+        return start_times, stop_times
+
+    def _add_optogenetics_metadata(self, nwbfile: NWBFile, opto_meta: dict, power_in_mW: float):
+        """Build all device + provenance objects and add OptogeneticExperimentMetadata.
+
+        Returns the populated ``OptogeneticSitesTable`` for use in ``OptogeneticEpochsTable``.
+        """
+        from ndx_ophys_devices import Effector, FiberInsertion, ViralVector, ViralVectorInjection
+        from ndx_optogenetics import (
+            ExcitationSource,
+            ExcitationSourceModel,
+            OpticalFiber,
+            OpticalFiberModel,
+            OptogeneticEffectors,
+            OptogeneticExperimentMetadata,
+            OptogeneticSitesTable,
+            OptogeneticViruses,
+            OptogeneticVirusInjections,
+        )
+
+        # ExcitationSourceModel
+        esm_meta = opto_meta.get("ExcitationSourceModel", {})
+        laser_model_kwargs = dict(
+            name=esm_meta["name"],
+            source_type=esm_meta.get("source_type"),
+            excitation_mode=esm_meta.get("excitation_mode"),
+            wavelength_range_in_nm=esm_meta.get("wavelength_range_in_nm"),
+        )
+        if esm_meta.get("manufacturer"):
+            laser_model_kwargs["manufacturer"] = esm_meta["manufacturer"]
+        if esm_meta.get("model_number"):
+            laser_model_kwargs["model_number"] = esm_meta["model_number"]
+        laser_model = ExcitationSourceModel(**laser_model_kwargs)
+        nwbfile.add_device_model(laser_model)
+
+        # ExcitationSource
+        es_meta = opto_meta.get("ExcitationSource", {})
+        laser_kwargs = dict(
+            name=es_meta["name"],
+            description=es_meta.get("description", ""),
+            model=laser_model,
+        )
+        if not math.isnan(power_in_mW):
+            laser_kwargs["power_in_W"] = power_in_mW / 1000.0
+        laser = ExcitationSource(**laser_kwargs)
+        nwbfile.add_device(laser)
+
+        # OpticalFiberModel
+        ofm_meta = opto_meta.get("OpticalFiberModel", {})
+        fiber_model = OpticalFiberModel(
+            name=ofm_meta["name"],
+            description=ofm_meta.get("description", ""),
+            manufacturer=ofm_meta.get("manufacturer"),
+            model_number=ofm_meta.get("model_number"),
+            numerical_aperture=float(ofm_meta["numerical_aperture"]),
+            core_diameter_in_um=float(ofm_meta["core_diameter_in_um"]),
+            ferrule_name=ofm_meta.get("ferrule_name"),
+            ferrule_diameter_in_mm=float(ofm_meta["ferrule_diameter_in_mm"])
+            if ofm_meta.get("ferrule_diameter_in_mm")
+            else None,
+        )
+        nwbfile.add_device_model(fiber_model)
+
+        # OpticalFiber instances
+        fiber_objects: dict[str, OpticalFiber] = {}
+        for spec in opto_meta.get("OpticalFibers", []):
+            insertion = FiberInsertion(
+                name="fiber_insertion",
+                insertion_position_ap_in_mm=spec.get("insertion_position_ap_in_mm"),
+                insertion_position_ml_in_mm=spec.get("insertion_position_ml_in_mm"),
+                insertion_position_dv_in_mm=spec.get("insertion_position_dv_in_mm"),
+                position_reference=spec.get("position_reference"),
+                hemisphere=spec.get("hemisphere"),
+            )
+            fiber = OpticalFiber(
+                name=spec["name"],
+                description=spec.get("description", ""),
+                model=fiber_model,
+                fiber_insertion=insertion,
+            )
+            nwbfile.add_device(fiber)
+            fiber_objects[spec["name"]] = fiber
+
+        # ViralVector
+        vv_meta = opto_meta.get("ViralVector", {})
+        virus = ViralVector(
+            name=vv_meta["name"],
+            construct_name=vv_meta["construct_name"],
+            manufacturer=vv_meta.get("manufacturer"),
+            titer_in_vg_per_ml=float(vv_meta["titer_in_vg_per_ml"]),
+            description=vv_meta.get("description", ""),
+        )
+
+        # VirusInjections
+        injection_objects: dict[str, ViralVectorInjection] = {}
+        hemisphere_to_injection: dict[str, str] = {}
+        for spec in opto_meta.get("VirusInjections", []):
+            inj = ViralVectorInjection(
+                name=spec["name"],
+                location=spec["location"],
+                hemisphere=spec["hemisphere"],
+                reference=spec.get("reference"),
+                ap_in_mm=spec["ap_in_mm"],
+                ml_in_mm=spec["ml_in_mm"],
+                dv_in_mm=spec["dv_in_mm"],
+                volume_in_uL=spec["volume_in_uL"],
+                viral_vector=virus,
+                description=spec.get("description", ""),
+            )
+            injection_objects[spec["name"]] = inj
+            hemisphere_to_injection[spec["hemisphere"]] = spec["name"]
+
+        # Effectors
+        effector_objects: list[Effector] = []
+        for spec in opto_meta.get("Effectors", []):
+            hemi = spec.get("hemisphere", "right")
+            inj_obj = injection_objects.get(hemisphere_to_injection.get(hemi))
+            effector = Effector(
+                name=spec["name"],
+                label=spec["label"],
+                description=spec.get("description", ""),
+                manufacturer=spec.get("manufacturer"),
+                viral_vector_injection=inj_obj,
+            )
+            effector_objects.append(effector)
+
+        # OptogeneticSitesTable
+        sites_meta = opto_meta.get("OptogeneticSitesTable", {})
+        sites_table = OptogeneticSitesTable(description=sites_meta.get("description", "Optogenetic stimulation sites."))
+        fiber_names = list(fiber_objects.keys())
+        for i, fiber_name in enumerate(fiber_names):
+            effector = effector_objects[i] if i < len(effector_objects) else effector_objects[0]
+            sites_table.add_row(
+                excitation_source=laser,
+                optical_fiber=fiber_objects[fiber_name],
+                effector=effector,
+            )
+
+        # OptogeneticExperimentMetadata
+        opto_experiment = OptogeneticExperimentMetadata(
+            stimulation_software=opto_meta.get("stimulation_software", "unknown"),
+            optogenetic_sites_table=sites_table,
+            optogenetic_effectors=OptogeneticEffectors(effectors=effector_objects),
+            optogenetic_viruses=OptogeneticViruses(viral_vectors=[virus]),
+            optogenetic_virus_injections=OptogeneticVirusInjections(
+                viral_vector_injections=list(injection_objects.values())
+            ),
+        )
+        nwbfile.add_lab_meta_data(opto_experiment)
+
+        return sites_table
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict | None = None,
+        stub_test: bool = False,
+        # Pulse-level stim parameters — fill from lab once confirmed; NaN/−1 until then.
+        pulse_length_in_ms: float = math.nan,
+        period_in_ms: float = math.nan,
+        number_pulses_per_pulse_train: int = -1,
+        number_trains: int = -1,
+        intertrain_interval_in_ms: float = math.nan,
+        power_in_mW: float = math.nan,
+    ) -> None:
+        import ndx_optogenetics  # noqa: F401 — register namespace
+        from ndx_optogenetics import OptogeneticEpochsTable
+
+        opto_meta = (metadata or {}).get("Optogenetics", {})
+        excitation_lambda = float(opto_meta.get("excitation_lambda", 635.0))
+
+        sites_table = self._add_optogenetics_metadata(nwbfile=nwbfile, opto_meta=opto_meta, power_in_mW=power_in_mW)
+
+        # Extract stimulation epochs using camera trigger timestamps for ABF-clock alignment
+        ttl = self._get_ttl()
+        trigger_times = _read_mat(self.source_data["file_path"])["camera_trigger_times"]
+        if stub_test:
+            ttl = ttl[:100]
+            trigger_times = trigger_times[:100]
+
+        start_times, stop_times = self._extract_epochs(ttl, trigger_times)
+        if len(start_times) == 0:
+            return
+
+        epochs_meta = opto_meta.get("OptogeneticEpochsTable", {})
+        epochs_table = OptogeneticEpochsTable(
+            name=epochs_meta.get("name", "OptogeneticEpochsTable"),
+            description=epochs_meta.get("description", "Optogenetic stimulation epochs."),
+            target_tables={"optogenetic_sites": sites_table},
+        )
+
+        site_indices = list(range(len(sites_table)))
+        for start, stop in zip(start_times, stop_times):
+            epochs_table.add_row(
+                start_time=float(start),
+                stop_time=float(stop),
+                stimulation_on=True,
+                pulse_length_in_ms=pulse_length_in_ms,
+                period_in_ms=period_in_ms,
+                number_pulses_per_pulse_train=number_pulses_per_pulse_train,
+                number_trains=number_trains,
+                intertrain_interval_in_ms=intertrain_interval_in_ms,
+                power_in_mW=power_in_mW,
+                wavelength_in_nm=excitation_lambda,
+                optogenetic_sites=site_indices,
+            )
+
+        nwbfile.add_time_intervals(epochs_table)

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/optogenetics_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/optogenetics_interface.py
@@ -9,8 +9,9 @@ camera-trigger-aligned binning) and writes:
 Confirmed stim parameters (from manuscript):
   - pulse_length_in_ms = 8.0 ms, period_in_ms = 16.0 ms (8 ms on / 8 ms off)
   - ~31 pulses per 500 ms train; trains spaced ≥ 20 s apart; 8 reps per power level
-  - Powers (pseudorandom order): 0.1, 0.5, 1.0, 4.0 mW — varies per epoch; leave as NaN
-    until per-epoch power can be read from stim_sequence data.
+  - Powers (pseudo-random order per stim_sequence): 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0 mW
+    Per-epoch power comes from stimulation sequence LRRK2.xlsx; ExcitationSource.power_in_W
+    stores the peak power and the description notes the full power range.
 """
 
 import math
@@ -42,26 +43,46 @@ class Chen2026OptogeneticsInterface(BaseDataInterface):
         return _read_mat(self.source_data["file_path"])["TTL"]
 
     @staticmethod
-    def _extract_epochs(ttl: np.ndarray, trigger_times: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        """Return (start_times_s, stop_times_s) for each contiguous block of TTL=1.
+    def _extract_epochs(
+        ttl: np.ndarray, trigger_times: np.ndarray, merge_gap_s: float = 1.0
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return (start_times_s, stop_times_s) for each stimulation train.
 
         Uses actual camera trigger timestamps so epoch times are aligned to the
         ABF recording clock (same reference as the raw FP acquisition).
+
+        The mat-file TTL is sampled at 100 Hz (one value per camera frame).
+        When the raw ABF TTL amplitude is low (<0.5 V), the 8 ms on/off pulses
+        alias unevenly across 10 ms camera frames, fragmenting each 500 ms train
+        into multiple short blobs separated by a few frames. We merge blobs whose
+        gap is smaller than merge_gap_s (default 1 s) to recover the true train
+        boundaries; inter-train intervals are ≥20 s so the threshold is unambiguous.
         """
         padded = np.concatenate([[0], ttl.astype(np.int8), [0]])
         diff = np.diff(padded)
-        # diff[k]==1  → ttl transitions 0→1 at index k  → trigger_times[k]
-        # diff[k]==-1 → ttl transitions 1→0 after index k-1; stop = trigger_times[k]
-        #   (or last trigger + 1 sample if k == len(trigger_times))
         start_indices = np.where(diff == 1)[0]
         stop_indices = np.where(diff == -1)[0]
         n = len(trigger_times)
         dt = trigger_times[-1] - trigger_times[-2] if n >= 2 else 0.01
-        start_times = trigger_times[start_indices]
-        stop_times = np.array([trigger_times[k] if k < n else trigger_times[-1] + dt for k in stop_indices])
-        return start_times, stop_times
+        raw_starts = trigger_times[start_indices]
+        raw_stops = np.array([trigger_times[k] if k < n else trigger_times[-1] + dt for k in stop_indices])
 
-    def _add_optogenetics_metadata(self, nwbfile: NWBFile, opto_meta: dict, power_in_mW: float):
+        if len(raw_starts) == 0:
+            return raw_starts, raw_stops
+
+        # Merge fragments of the same train (gap < merge_gap_s)
+        merged_starts = [raw_starts[0]]
+        merged_stops = [raw_stops[0]]
+        for s, e in zip(raw_starts[1:], raw_stops[1:]):
+            if s - merged_stops[-1] < merge_gap_s:
+                merged_stops[-1] = e
+            else:
+                merged_starts.append(s)
+                merged_stops.append(e)
+
+        return np.array(merged_starts), np.array(merged_stops)
+
+    def _add_optogenetics_metadata(self, nwbfile: NWBFile, opto_meta: dict, power_in_mW: list | float):
         """Build all device + provenance objects and add OptogeneticExperimentMetadata.
 
         Returns the populated ``OptogeneticSitesTable`` for use in ``OptogeneticEpochsTable``.
@@ -96,13 +117,25 @@ class Chen2026OptogeneticsInterface(BaseDataInterface):
 
         # ExcitationSource
         es_meta = opto_meta.get("ExcitationSource", {})
+        peak_power_mW = max(power_in_mW) if isinstance(power_in_mW, list) else power_in_mW
+        base_description = es_meta.get("description", "")
+        if isinstance(power_in_mW, list):
+            unique_powers = sorted(set(power_in_mW))
+            power_note = (
+                f" Power varied pseudo-randomly across epochs {unique_powers} mW; "
+                f"power_in_W reflects the peak power ({peak_power_mW} mW). "
+                f"Per-epoch power is recorded in the OptogeneticEpochsTable."
+            )
+            description = base_description + power_note
+        else:
+            description = base_description
         laser_kwargs = dict(
             name=es_meta["name"],
-            description=es_meta.get("description", ""),
+            description=description,
             model=laser_model,
         )
-        if not math.isnan(power_in_mW):
-            laser_kwargs["power_in_W"] = power_in_mW / 1000.0
+        if not math.isnan(peak_power_mW):
+            laser_kwargs["power_in_W"] = peak_power_mW / 1000.0
         laser = ExcitationSource(**laser_kwargs)
         nwbfile.add_device(laser)
 
@@ -216,13 +249,14 @@ class Chen2026OptogeneticsInterface(BaseDataInterface):
         nwbfile: NWBFile,
         metadata: dict | None = None,
         stub_test: bool = False,
-        # Pulse-level stim parameters — fill from lab once confirmed; NaN/−1 until then.
+        # Pulse-level stim parameters
         pulse_length_in_ms: float = math.nan,
         period_in_ms: float = math.nan,
         number_pulses_per_pulse_train: int = -1,
         number_trains: int = -1,
         intertrain_interval_in_ms: float = math.nan,
-        power_in_mW: float = math.nan,
+        # Per-epoch power list (one entry per stimulation epoch) or a single scalar.
+        power_in_mW: list | float = math.nan,
     ) -> None:
         import ndx_optogenetics  # noqa: F401 — register namespace
         from ndx_optogenetics import OptogeneticEpochsTable
@@ -251,7 +285,11 @@ class Chen2026OptogeneticsInterface(BaseDataInterface):
         )
 
         site_indices = list(range(len(sites_table)))
-        for start, stop in zip(start_times, stop_times):
+        for i, (start, stop) in enumerate(zip(start_times, stop_times)):
+            if isinstance(power_in_mW, list):
+                epoch_power = float(power_in_mW[i]) if i < len(power_in_mW) else math.nan
+            else:
+                epoch_power = power_in_mW
             epochs_table.add_row(
                 start_time=float(start),
                 stop_time=float(stop),
@@ -261,7 +299,7 @@ class Chen2026OptogeneticsInterface(BaseDataInterface):
                 number_pulses_per_pulse_train=number_pulses_per_pulse_train,
                 number_trains=number_trains,
                 intertrain_interval_in_ms=intertrain_interval_in_ms,
-                power_in_mW=power_in_mW,
+                power_in_mW=epoch_power,
                 wavelength_in_nm=excitation_lambda,
                 optogenetic_sites=site_indices,
             )

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/optogenetics_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/optogenetics_interface.py
@@ -6,12 +6,13 @@ camera-trigger-aligned binning) and writes:
   - ``OptogeneticExperimentMetadata`` (lab_meta_data): LED, fiber, virus, injection, effector
   - ``OptogeneticEpochsTable`` (intervals): one row per contiguous TTL-on epoch
 
-Confirmed stim parameters (from manuscript):
-  - pulse_length_in_ms = 8.0 ms, period_in_ms = 16.0 ms (8 ms on / 8 ms off)
-  - ~31 pulses per 500 ms train; trains spaced ≥ 20 s apart; 8 reps per power level
-  - Powers (pseudo-random order per stim_sequence): 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0 mW
-    Per-epoch power comes from stimulation sequence LRRK2.xlsx; ExcitationSource.power_in_W
-    stores the peak power and the description notes the full power range.
+Stim parameters measured from raw ABF (2000 Hz, channel 2 = opto_TTL):
+  Epochs 1–32 (high amplitude, ~1.2 V): 32 pulses, 9 ms ON / 1 ms OFF, 10 ms period, ~320 ms train
+  Epochs 33–64 (low amplitude, ~0.05 V): 32 pulses, 8 ms ON / 8 ms OFF, 16 ms period, ~505 ms train
+  Trains spaced ≥ 20 s apart; 8 reps per power level (64 trains total).
+  Powers (pseudo-random order per stim_sequence): 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0 mW
+  Per-epoch power comes from stimulation sequence LRRK2.xlsx; ExcitationSource.power_in_W
+  stores the peak power and the description notes the full power range.
 """
 
 import math
@@ -249,14 +250,13 @@ class Chen2026OptogeneticsInterface(BaseDataInterface):
         nwbfile: NWBFile,
         metadata: dict | None = None,
         stub_test: bool = False,
-        # Pulse-level stim parameters
-        pulse_length_in_ms: float = math.nan,
-        period_in_ms: float = math.nan,
-        number_pulses_per_pulse_train: int = -1,
+        # Per-epoch pulse parameters — one value per stimulation epoch.
+        pulse_length_in_ms: list[float] = (),
+        period_in_ms: list[float] = (),
+        number_pulses_per_pulse_train: list[int] = (),
         number_trains: int = -1,
         intertrain_interval_in_ms: float = math.nan,
-        # Per-epoch power list (one entry per stimulation epoch) or a single scalar.
-        power_in_mW: list | float = math.nan,
+        power_in_mW: list[float] = (),
     ) -> None:
         import ndx_optogenetics  # noqa: F401 — register namespace
         from ndx_optogenetics import OptogeneticEpochsTable
@@ -286,20 +286,16 @@ class Chen2026OptogeneticsInterface(BaseDataInterface):
 
         site_indices = list(range(len(sites_table)))
         for i, (start, stop) in enumerate(zip(start_times, stop_times)):
-            if isinstance(power_in_mW, list):
-                epoch_power = float(power_in_mW[i]) if i < len(power_in_mW) else math.nan
-            else:
-                epoch_power = power_in_mW
             epochs_table.add_row(
                 start_time=float(start),
                 stop_time=float(stop),
                 stimulation_on=True,
-                pulse_length_in_ms=pulse_length_in_ms,
-                period_in_ms=period_in_ms,
-                number_pulses_per_pulse_train=number_pulses_per_pulse_train,
+                pulse_length_in_ms=pulse_length_in_ms[i],
+                period_in_ms=period_in_ms[i],
+                number_pulses_per_pulse_train=number_pulses_per_pulse_train[i],
                 number_trains=number_trains,
                 intertrain_interval_in_ms=intertrain_interval_in_ms,
-                power_in_mW=epoch_power,
+                power_in_mW=power_in_mW[i],
                 wavelength_in_nm=excitation_lambda,
                 optogenetic_sites=site_indices,
             )

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/processed_fiber_photometry_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/processed_fiber_photometry_interface.py
@@ -173,6 +173,10 @@ class Chen2026ProcessedFiberPhotometryInterface(BaseFiberPhotometryInterface):
     """
 
     def add_to_nwbfile(self, nwbfile, metadata, **conversion_options):
+        # CommandedVoltageSeries is not available for the processed FP data
+        fiber_photometry_metadata = metadata.get("FiberPhotometry", {})
+        if "CommandedVoltageSeries" in fiber_photometry_metadata:
+            fiber_photometry_metadata.pop("CommandedVoltageSeries", None)
         super().add_to_nwbfile(nwbfile=nwbfile, metadata=metadata, **conversion_options)
 
         series_name = metadata["FiberPhotometry"][self.metadata_key]["name"]

--- a/src/dombeck_lab_to_nwb/chen2026/metadata/general_metadata.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/metadata/general_metadata.yaml
@@ -53,10 +53,7 @@ SessionDescriptions:
 Subject:
   species: Mus musculus
   strain: C57BL/6J
-  # Approximate age: surgeries at ~6 months; recordings ~4 weeks post-surgery.
-  age: P210D
-  # TODO: confirm per-animal sex with lab; using "U" (unknown) until records are provided.
-  sex: U
+  # sex and date_of_birth are set per-animal at runtime from metadata-LRRK2-chen2026.xlsx
   # genotype is set per-animal at runtime ("LRRK2-WT" or "LRRK2-G2019S")
 
 # Per-group subject descriptions (set as Subject.description in the NWB file).

--- a/src/dombeck_lab_to_nwb/chen2026/metadata/optogenetics.yaml
+++ b/src/dombeck_lab_to_nwb/chen2026/metadata/optogenetics.yaml
@@ -1,0 +1,119 @@
+# Optogenetics metadata for Chen et al. 2026 (LRRK2 dataset).
+#
+# ChRmine-mScarlet expressed in Cre+ SNc dopamine neurons via Cre-dependent AAV5.
+# Activated with a 635 nm red LED (LEDFRJ_635, Doric Lenses) via a 400 µm optical
+# fiber (4 mm ferrule) implanted just above right SNc.
+# TTL signal (100 Hz, binned) is stored in the *_data.mat file and read from there.
+#
+# Confirmed from manuscript (Chen et al. 2026):
+#   - LED: LEDFRJ_635, Doric Lenses; software: Doric Studio (Doric Lenses)
+#   - Craniotomy: AP -3.20 mm, ML +1.60 mm from bregma (right hemisphere)
+#   - Fiber: 4 mm long, 400 µm core, model MFC_400/430-0.66_4.0mm_TS3.0_C60
+#   - ChRmine injection: 4 depths (−3.8, −4.1, −4.4, −4.7 mm from dura), 0.1 µL/depth
+#   - Stim: 8 ms on / 8 ms off pulses, 500 ms trains, ≥20 s between trains, 8 reps/power
+#   - Powers: 0.1, 0.5, 1.0, 4.0 mW (pseudorandom order)
+
+Optogenetics:
+  excitation_lambda: 635.0  # nm
+  stimulation_software: "Doric Studio (Doric Lenses)"
+
+  ExcitationSourceModel:
+    name: led_635nm_model
+    manufacturer: "Doric Lenses"
+    model_number: "LEDFRJ_635"
+    source_type: "LED"
+    excitation_mode: "one-photon"
+    wavelength_range_in_nm: [630.0, 640.0]  # 635 nm nominal
+
+  ExcitationSource:
+    name: led_635nm
+    description: >-
+      635 nm red LED (LEDFRJ_635, Doric Lenses) for Cre-dependent ChRmine optogenetic
+      activation of SNc dopamine neurons (right hemisphere). Coupled via fiber-optic patch
+      cord to the implanted 400 µm fiber cannula. Frequency, power, and duration controlled
+      by Doric Studio software with stimulation trains triggered by a custom LabVIEW script.
+
+  OpticalFiberModel:
+    name: optical_fiber_model_snc
+    description: >-
+      Doric Lenses 4 mm fiber cannula for optogenetic stimulation of SNc.
+      Ferrule length 4 mm corresponds to implant depth from dura surface.
+      Model MFC_400/430-0.66_4.0mm_TS3.0_C60.
+    manufacturer: Doric Lenses
+    model_number: MFC_400/430-0.66_4.0mm_TS3.0_C60
+    numerical_aperture: 0.66
+    core_diameter_in_um: 400.0
+
+  OpticalFibers:
+    - name: optical_fiber_snc
+      hemisphere: right
+      # Craniotomy and fiber placement: -3.20 mm caudal, +1.60 mm lateral from bregma (right SNc).
+      # Fiber ferrule length 4 mm = tip depth from dura surface.
+      insertion_position_ap_in_mm: -3.20
+      insertion_position_ml_in_mm: 1.60
+      insertion_position_dv_in_mm: 4.00
+      position_reference: "Bregma at cortical surface (AP/ML); dura surface (DV)"
+      description: >-
+        Optical fiber for optogenetic stimulation of ChRmine-expressing Cre+ SNc dopamine
+        neurons, right hemisphere. Implanted via craniotomy at AP -3.20 mm, ML +1.60 mm
+        from bregma. Ferrule length 4 mm = tip depth of 4.00 mm from dura surface.
+
+  ViralVector:
+    name: viral_vector_chrmine
+    construct_name: pAAV-Ef1a-DIO-ChRmine-mScarlet-WPRE
+    manufacturer: Addgene
+    titer_in_vg_per_ml: 2.2e13
+    description: >-
+      AAV5 serotype. Addgene catalog #130998. Titer 2.20×10¹³ vg/mL. Cre-dependent
+      expression of ChRmine-mScarlet in SNc dopamine neurons.
+
+  VirusInjections:
+    - name: snc_injection_right
+      location: "substantia nigra pars compacta"
+      hemisphere: right
+      reference: "Bregma at cortical surface (AP/ML); dura surface (DV)"
+      # Craniotomy at AP -3.20 mm, ML +1.60 mm from bregma (right hemisphere).
+      # Four injection depths: -3.8, -4.1, -4.4, -4.7 mm ventral from dura (0.1 µL each).
+      # DV below uses centroid of the four depths; total volume 0.40 µL (4 × 0.10 µL).
+      ap_in_mm: -3.20
+      ml_in_mm: 1.60
+      dv_in_mm: -4.25
+      volume_in_uL: 0.40
+      description: >-
+        Right SNc injection of pAAV-Ef1a-DIO-ChRmine-mScarlet-WPRE (Addgene #130998, AAV5,
+        2.20×10¹³ vg/mL). Four injection depths: −3.8, −4.1, −4.4, −4.7 mm ventral from
+        dura surface; 0.1 µL per depth (0.4 µL total); injected via pulled glass micropipette.
+
+  Effectors:
+    - name: ChRmine_right
+      hemisphere: right
+      label: ChRmine
+      manufacturer: Addgene
+      description: >-
+        Red-shifted channelrhodopsin ChRmine fused to mScarlet, expressed in Cre+ SNc dopamine
+        neurons via Cre-dependent AAV5 (Addgene #130998). Activated with 635 nm LED light.
+
+  OptogeneticSitesTable:
+    description: >-
+      Right-hemisphere SNc optogenetic stimulation site. Cre+ dopamine neurons express
+      ChRmine-mScarlet via Cre-dependent AAV5 (Addgene #130998) and are activated with
+      a 635 nm LED (LEDFRJ_635, Doric Lenses) via a 400 µm optical fiber
+      (Doric MFC_400/430-0.66_4.0mm_TS3.0_C60, 4 mm ferrule).
+    columns:
+      - name: excitation_source
+        description: "635 nm LED (LEDFRJ_635, Doric Lenses) for ChRmine optogenetic stimulation."
+      - name: optical_fiber
+        description: "400 µm optical fiber (Doric MFC_400/430-0.66_4.0mm_TS3.0_C60) implanted in right SNc."
+      - name: effector
+        description: "ChRmine-mScarlet expressed in Cre+ SNc dopamine neurons."
+
+  OptogeneticEpochsTable:
+    name: OptogeneticEpochsTable
+    description: >-
+      Epochs of optogenetic activation of ChRmine-expressing Cre+ SNc dopamine neurons
+      (635 nm LED, right hemisphere). Each row is one contiguous stimulation epoch
+      (TTL=1 block) extracted from the 100 Hz binned TTL column in *_data.mat.
+      Pulse parameters: 8 ms on / 8 ms off cycles for 500 ms per train; trains spaced
+      at least 20 s apart; 8 repetitions per power level (0.1, 0.5, 1.0, 4.0 mW,
+      pseudorandom order). Power and pulse parameters are passed per-session via
+      conversion_options once confirmed.

--- a/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
+++ b/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
@@ -1,6 +1,11 @@
 from neuroconv import NWBConverter
 
-from .interfaces import Chen2026ProcessedFiberPhotometryInterface, Chen2026RawFiberPhotometryInterface
+from .interfaces import (
+    Chen2026BehaviorInterface,
+    Chen2026OptogeneticsInterface,
+    Chen2026ProcessedFiberPhotometryInterface,
+    Chen2026RawFiberPhotometryInterface,
+)
 
 
 class Chen2026NWBConverter(NWBConverter):
@@ -16,6 +21,8 @@ class Chen2026NWBConverter(NWBConverter):
       CorrectedIsosbestic    — baseline-corrected 405 nm (corrected405, 100 Hz)
       DfOverF                — % ΔF/F 470 nm, smoothed (dff470, 100 Hz)
       DfOverFIsosbestic      — % ΔF/F 405 nm, smoothed (dff405, 100 Hz)
+      Behavior               — treadmill velocity (m/s) and acceleration (m/s²)
+      Optogenetics           — stimulation epochs from TTL column
     """
 
     data_interface_classes = dict(
@@ -25,4 +32,6 @@ class Chen2026NWBConverter(NWBConverter):
         CorrectedIsosbestic=Chen2026ProcessedFiberPhotometryInterface,
         DfOverF=Chen2026ProcessedFiberPhotometryInterface,
         DfOverFIsosbestic=Chen2026ProcessedFiberPhotometryInterface,
+        Behavior=Chen2026BehaviorInterface,
+        Optogenetics=Chen2026OptogeneticsInterface,
     )


### PR DESCRIPTION
This pull request adds support for optogenetics and behavioral data to the Chen et al. 2026 (LRRK2) NWB conversion pipeline. It introduces new interfaces for extracting optogenetic stimulation epochs and treadmill behavioral data from MATLAB files, updates metadata handling, and adds the necessary dependencies and documentation.

Example file for reference: [sub-302-calb-gs_ses-2025-11-10-0005.nwb](https://drive.google.com/file/d/1tMl3zA9tihh0sSI6mupF57dOdjzgw8ue/view?usp=drive_link)

Tutorial notebook [here](https://github.com/catalystneuro/dombeck-lab-to-nwb/blob/82550db4f4ae1d32f60f9c3ab5f5ac73bff50b96/src/dombeck_lab_to_nwb/chen2026/tutorials/chen2026_demo.ipynb
) to aid the review.


**New interfaces for optogenetics and behavior:**

* Added `Chen2026OptogeneticsInterface` to extract optogenetic stimulation epochs and associated experimental metadata from `*_data.mat` files, writing them to NWB using the `ndx-optogenetics` extension. This includes detailed device, fiber, virus, and effector provenance, as well as stimulation epoch tables. [[1]](diffhunk://#diff-35f0a43a86a37f8758c936986576e15e9fffe884310e243d43ebd7f1d231d704R1-R269) [[2]](diffhunk://#diff-cfabb5a3277b7f0586e8328f2758ffc4951284dc2ae11a4731a6d58ef25a9c65R1-R10)
* Added `Chen2026BehaviorInterface` to extract treadmill velocity and acceleration from `*_data.mat` files and write them as a `BehavioralTimeSeries` to the NWB file. [[1]](diffhunk://#diff-5c2f1c60ab4d1f197eeb239463566f6b855f7c84a41a0323fb1c2c24cd8db2a1R1-R79) [[2]](diffhunk://#diff-cfabb5a3277b7f0586e8328f2758ffc4951284dc2ae11a4731a6d58ef25a9c65R1-R10)

**Pipeline and metadata integration:**

* Updated `convert_session.py` to include the new behavior and optogenetics interfaces when a MATLAB file is provided, and to merge optogenetics metadata from YAML. Also, added default/confirmed stimulation parameters to the optogenetics interface, following the experimental methods. [[1]](diffhunk://#diff-fed65935e5caaf61ea73023b7bb02db57181494d2f2dfd483a73d88a7e9b725dL102-R102) [[2]](diffhunk://#diff-fed65935e5caaf61ea73023b7bb02db57181494d2f2dfd483a73d88a7e9b725dR127-R132) [[3]](diffhunk://#diff-fed65935e5caaf61ea73023b7bb02db57181494d2f2dfd483a73d88a7e9b725dR142-R145) [[4]](diffhunk://#diff-fed65935e5caaf61ea73023b7bb02db57181494d2f2dfd483a73d88a7e9b725dR173-R185)

**Dependency and documentation updates:**

* Added `ndx-optogenetics>=0.4.0` as a required dependency in the environment file.
* Expanded the conversion notes to document the optogenetics surgery coordinates, injection protocols, and confirmed stimulation parameters for both experimental groups.