### PR TITLE
Add `opto_ttl` from ABF file for LRRK2 dataset

### DIFF
--- a/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
+++ b/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
@@ -248,7 +248,39 @@ The trigger spacing is nominally 10 ms (100 Hz) with ±0.5 ms quantization noise
 
 ---
 
+### NWB File Content Summary
+
+Each converted `.nwb` file contains:
+
+| Location | Object | Source | Notes |
+|----------|--------|--------|-------|
+| `acquisition/` | `FiberPhotometryResponseSeriesRawSignal` | ABF `520sig` (470 nm demux) | 2000 Hz, explicit timestamps |
+| `acquisition/` | `FiberPhotometryResponseSeriesIsosbesticControl` | ABF `520sig` (405 nm demux) | 2000 Hz, explicit timestamps |
+| `processing/ophys/` | `FiberPhotometryResponseSeriesCorrectedSignal` | `_data.mat` `corrected470` | 100 Hz, camera-trigger timestamps |
+| `processing/ophys/` | `FiberPhotometryResponseSeriesCorrectedIsosbestic` | `_data.mat` `corrected405` | 100 Hz, camera-trigger timestamps |
+| `processing/ophys/` | `FiberPhotometryResponseSeriesDfOverF` | `_data.mat` `dff470` | 100 Hz, camera-trigger timestamps |
+| `processing/ophys/` | `FiberPhotometryResponseSeriesDfOverFIsosbestic` | `_data.mat` `dff405` | 100 Hz, camera-trigger timestamps |
+| `processing/behavior/` | `BehavioralTimeSeries` → `velocity`, `acceleration` | `_data.mat` `velocity`, `acceleration` | 100 Hz, camera-trigger timestamps |
+| `intervals/` | `OptogeneticEpochsTable` | `_data.mat` `TTL` (merged) | 64 train epochs; per-epoch pulse params and power |
+| `events/` | `OptoPulse` | ABF `opto_TTL` channel (rising+falling edges, threshold 0.01 V) | ~2048 interval events; onset + duration per individual pulse |
+
+The raw ABF is the sole source for `events/`. Camera frame times are not stored as a separate EventsTable because they are already the explicit timestamps of every 100 Hz processed series — duplicating ~129k rows would add significant write time without new information.
+
+---
+
 ### Implementation Notes
+
+#### ABF Events Interface (`Chen2026ABFEventsInterface`)
+
+Class in `interfaces/events_interface.py`, registered as `ABFEvents` in the converter.
+
+Returns two `_EventsData` records from `_get_events_data_dict()`:
+
+- **`opto_pulse`** → `OptoPulse` `EventsTable`: rising/falling edge pairs from the `opto_TTL` channel (threshold 0.01 V). Each row has a `timestamp` (pulse onset) and `duration` (pulse width in seconds). The 0.01 V threshold catches both high-amplitude trains (~1.2 V, epochs 0–31) and low-amplitude trains (~0.05 V, epochs 32–63) without the aliasing problem that affects the 100 Hz mat-file TTL. ~2048 rows total (64 trains × 32 pulses).
+
+Camera frame trigger times are not stored as a separate EventsTable: they are already the explicit timestamps on every 100 Hz processed series and duplicating ~129k rows would add significant write time without new information. The interface reads the ABF once (not sharing the `_DEMUX_CACHE` used by `Chen2026RawFiberPhotometryInterface`).
+
+The interface is always present in the converter (not conditional on `mat_file`); `convert_session.py` includes `"ABFEvents"` in both `source_data` and `conversion_options`.
 
 #### Processed series routing to `processing/ophys`
 

--- a/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
+++ b/src/dombeck_lab_to_nwb/chen2026/conversion_notes.md
@@ -248,7 +248,39 @@ The trigger spacing is nominally 10 ms (100 Hz) with ±0.5 ms quantization noise
 
 ---
 
+### NWB File Content Summary
+
+Each converted `.nwb` file contains:
+
+| Location | Object | Source | Notes |
+|----------|--------|--------|-------|
+| `acquisition/` | `FiberPhotometryResponseSeriesRawSignal` | ABF `520sig` (470 nm demux) | 2000 Hz, explicit timestamps |
+| `acquisition/` | `FiberPhotometryResponseSeriesIsosbesticControl` | ABF `520sig` (405 nm demux) | 2000 Hz, explicit timestamps |
+| `processing/ophys/` | `FiberPhotometryResponseSeriesCorrectedSignal` | `_data.mat` `corrected470` | 100 Hz, camera-trigger timestamps |
+| `processing/ophys/` | `FiberPhotometryResponseSeriesCorrectedIsosbestic` | `_data.mat` `corrected405` | 100 Hz, camera-trigger timestamps |
+| `processing/ophys/` | `FiberPhotometryResponseSeriesDfOverF` | `_data.mat` `dff470` | 100 Hz, camera-trigger timestamps |
+| `processing/ophys/` | `FiberPhotometryResponseSeriesDfOverFIsosbestic` | `_data.mat` `dff405` | 100 Hz, camera-trigger timestamps |
+| `processing/behavior/` | `BehavioralTimeSeries` → `velocity`, `acceleration` | `_data.mat` `velocity`, `acceleration` | 100 Hz, camera-trigger timestamps |
+| `intervals/` | `OptogeneticEpochsTable` | `_data.mat` `TTL` (merged) | 64 train epochs; per-epoch pulse params and power |
+| `events/` | `OptoTTL` | ABF `opto_TTL` channel (rising+falling edges, threshold 0.01 V) | ~2048 interval events; onset + duration per individual pulse |
+
+The raw ABF is the sole source for `events/`. Camera frame times are not stored as a separate EventsTable because they are already the explicit timestamps of every 100 Hz processed series — duplicating ~129k rows would add significant write time without new information.
+
+---
+
 ### Implementation Notes
+
+#### ABF Events Interface (`Chen2026ABFEventsInterface`)
+
+Class in `interfaces/events_interface.py`, registered as `ABFEvents` in the converter.
+
+Returns two `_EventsData` records from `_get_events_data_dict()`:
+
+- **`opto_pulse`** → `OptoTTL` `EventsTable`: rising/falling edge pairs from the `opto_TTL` channel (threshold 0.01 V). Each row has a `timestamp` (pulse onset) and `duration` (pulse width in seconds). The 0.01 V threshold catches both high-amplitude trains (~1.2 V, epochs 0–31) and low-amplitude trains (~0.05 V, epochs 32–63) without the aliasing problem that affects the 100 Hz mat-file TTL. ~2048 rows total (64 trains × 32 pulses).
+
+Camera frame trigger times are not stored as a separate EventsTable: they are already the explicit timestamps on every 100 Hz processed series and duplicating ~129k rows would add significant write time without new information. The interface reads the ABF once (not sharing the `_DEMUX_CACHE` used by `Chen2026RawFiberPhotometryInterface`).
+
+The interface is always present in the converter (not conditional on `mat_file`); `convert_session.py` includes `"ABFEvents"` in both `source_data` and `conversion_options`.
 
 #### Processed series routing to `processing/ophys`
 

--- a/src/dombeck_lab_to_nwb/chen2026/convert_session.py
+++ b/src/dombeck_lab_to_nwb/chen2026/convert_session.py
@@ -108,6 +108,9 @@ def convert_session(
             "stream_names": ["405nm"],
             "metadata_key": metadata_keys["IsosbesticControl"],
         },
+        "ABFEvents": {
+            "file_path": str(file_path),
+        },
     }
 
     # Processed + optogenetics interfaces — present only when mat_file is provided
@@ -176,6 +179,7 @@ def convert_session(
     conversion_options: dict = {
         "RawSignal": {"stub_test": stub_test},
         "IsosbesticControl": {"stub_test": stub_test},
+        "ABFEvents": {},
     }
     if mat_file is not None:
         conversion_options.update(

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/__init__.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/__init__.py
@@ -1,4 +1,5 @@
 from .behavior_interface import Chen2026BehaviorInterface
+from .events_interface import Chen2026ABFEventsInterface
 from .optogenetics_interface import Chen2026OptogeneticsInterface
 from .processed_fiber_photometry_interface import Chen2026ProcessedFiberPhotometryInterface
 from .raw_fiber_photometry_interface import Chen2026RawFiberPhotometryInterface
@@ -8,4 +9,5 @@ __all__ = [
     "Chen2026ProcessedFiberPhotometryInterface",
     "Chen2026OptogeneticsInterface",
     "Chen2026BehaviorInterface",
+    "Chen2026ABFEventsInterface",
 ]

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/events_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/events_interface.py
@@ -1,19 +1,19 @@
 """Raw ABF events interface for Chen et al. 2026 (LRRK2 dataset).
 
-Reads two TTL channels from the raw ABF file and writes them as
-``pynwb.event.EventsTable`` objects in ``nwbfile.events``:
+Reads the opto_TTL channel from the raw ABF file and writes individual
+optogenetic pulses as an ``OptoPulse`` ``EventsTable`` in ``nwbfile.events``.
 
-  CameraFrameTrigger  — rising edges of the camera frame-sync TTL
-      (ABF channel 'camera', 100 Hz, point events)
-      Each timestamp is the onset of one camera frame and the shared time base
-      for all 100 Hz processed signals in the companion *_data.mat file.
-
-  OptoPulse           — individual optogenetic pulses from the raw TTL
-      (ABF channel 'opto_TTL', 2000 Hz, interval events)
+  OptoPulse — individual optogenetic pulses (interval events)
+      (ABF channel 'opto_TTL', 2000 Hz)
       Pulse-level events complementing the train-level OptogeneticEpochsTable.
       Both halves of the session are detectable at 2 kHz (threshold 0.01 V):
         epochs 0-31  (~1.2 V): 32 pulses per train, 9 ms on / 1 ms off
         epochs 32-63 (~0.05 V): 32 pulses per train, 8 ms on / 8 ms off
+
+Note: camera frame trigger times are not stored as a separate EventsTable because
+they are already the explicit timestamps of every 100 Hz processed series
+(corrected FP, ΔF/F, velocity, acceleration) and duplicating ~129k rows would
+add significant write time without new information.
 """
 
 from pathlib import Path
@@ -22,24 +22,23 @@ import numpy as np
 from neuroconv.datainterfaces.events.baseeventsinterface import BaseEventsInterface, _EventsData
 
 
-_CAMERA_THRESHOLD_V = 1.0  # V — rising-edge threshold for camera TTL
 _OPTO_THRESHOLD_V = 0.01  # V — threshold for opto_TTL (catches both ~1.2 V and ~0.05 V trains)
 _SAMPLE_RATE = 2000.0  # Hz — ABF acquisition rate
 
 
 class Chen2026ABFEventsInterface(BaseEventsInterface):
-    """Camera frame-trigger and opto pulse events from the raw ABF file.
+    """Individual optogenetic pulse events from the raw ABF opto_TTL channel.
 
-    Writes two ``EventsTable`` objects in ``nwbfile.events``:
+    Writes one ``EventsTable`` in ``nwbfile.events``:
 
-    * ``CameraFrameTrigger`` — ~129 k timestamp-only point events (one per frame).
-    * ``OptoPulse``          — ~2048 interval events (onset + duration for each
-      individual optogenetic pulse; 32 pulses × 64 trains).
+    * ``OptoPulse`` — ~2048 interval events (onset + duration per pulse;
+      32 pulses × 64 trains). Complements the train-level
+      ``OptogeneticEpochsTable`` in ``nwbfile.intervals``.
     """
 
-    display_name = "Chen2026 ABF Events (camera trigger + opto pulses)"
+    display_name = "Chen2026 ABF Events (opto pulses)"
     associated_suffixes = (".abf",)
-    info = "Interface for camera frame-trigger and optogenetic pulse events from the ABF file."
+    info = "Interface for individual optogenetic pulse events from the ABF opto_TTL channel."
 
     metadata_key = "ABFEvents"
 
@@ -50,16 +49,12 @@ class Chen2026ABFEventsInterface(BaseEventsInterface):
         metadata = super().get_metadata()
         metadata.setdefault("Events", {})[self.metadata_key] = {
             "event_types": {
-                "camera_trigger": {
-                    "event_name": "CameraFrameTrigger",
-                    "event_description": ("Rising edge of the camera frame-sync TTL."),
-                },
                 "opto_pulse": {
                     "event_name": "OptoTTL",
                     "event_description": (
                         "Individual optogenetic pulse from the raw ABF opto_TTL channel (2000 Hz, "
-                        "threshold 0.01 V). Each row is one TTL-high pulse; start_time is the rising "
-                        "edge and duration is the pulse width. Complements the train-level "
+                        "threshold 0.01 V). Each row is one TTL-high pulse; timestamp is the rising "
+                        "edge and duration is the pulse width in seconds. Complements the train-level "
                         "OptogeneticEpochsTable: epochs 0-31 (~1.2 V) have 32 pulses at ~9 ms each; "
                         "epochs 32-63 (~0.05 V) have 32 pulses at ~8 ms each."
                     ),
@@ -77,13 +72,6 @@ class Chen2026ABFEventsInterface(BaseEventsInterface):
         abf = pyabf.ABF(self.source_data["file_path"], loadData=True)
         channel_names = [abf.adcNames[i].strip() for i in range(abf.channelCount)]
 
-        # ── camera frame trigger (point events) ──────────────────────────────
-        cam_idx = channel_names.index("camera")
-        cam = abf.data[cam_idx]
-        above_cam = cam > _CAMERA_THRESHOLD_V
-        cam_rising = np.where(np.diff(above_cam.astype(np.int8)) == 1)[0]
-        cam_timestamps = cam_rising / _SAMPLE_RATE
-
         # ── opto pulse (interval events) ─────────────────────────────────────
         opto_idx = channel_names.index("opto_TTL")
         opto = abf.data[opto_idx]
@@ -99,18 +87,11 @@ class Chen2026ABFEventsInterface(BaseEventsInterface):
         rising = rising[:n_pulses]
         falling = falling[:n_pulses]
 
-        opto_timestamps = rising / _SAMPLE_RATE
-        opto_durations = (falling - rising) / _SAMPLE_RATE
-
         self._events_data_dict = {
-            "camera_trigger": _EventsData(
-                event_type_source_id="camera_trigger",
-                timestamps=cam_timestamps,
-            ),
             "opto_pulse": _EventsData(
                 event_type_source_id="opto_pulse",
-                timestamps=opto_timestamps,
-                durations=opto_durations,
+                timestamps=rising / _SAMPLE_RATE,
+                durations=(falling - rising) / _SAMPLE_RATE,
             ),
         }
         return self._events_data_dict

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/events_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/events_interface.py
@@ -1,0 +1,116 @@
+"""Raw ABF events interface for Chen et al. 2026 (LRRK2 dataset).
+
+Reads two TTL channels from the raw ABF file and writes them as
+``pynwb.event.EventsTable`` objects in ``nwbfile.events``:
+
+  CameraFrameTrigger  — rising edges of the camera frame-sync TTL
+      (ABF channel 'camera', 100 Hz, point events)
+      Each timestamp is the onset of one camera frame and the shared time base
+      for all 100 Hz processed signals in the companion *_data.mat file.
+
+  OptoPulse           — individual optogenetic pulses from the raw TTL
+      (ABF channel 'opto_TTL', 2000 Hz, interval events)
+      Pulse-level events complementing the train-level OptogeneticEpochsTable.
+      Both halves of the session are detectable at 2 kHz (threshold 0.01 V):
+        epochs 0-31  (~1.2 V): 32 pulses per train, 9 ms on / 1 ms off
+        epochs 32-63 (~0.05 V): 32 pulses per train, 8 ms on / 8 ms off
+"""
+
+from pathlib import Path
+
+import numpy as np
+from neuroconv.datainterfaces.events.baseeventsinterface import BaseEventsInterface, _EventsData
+
+
+_CAMERA_THRESHOLD_V = 1.0  # V — rising-edge threshold for camera TTL
+_OPTO_THRESHOLD_V = 0.01  # V — threshold for opto_TTL (catches both ~1.2 V and ~0.05 V trains)
+_SAMPLE_RATE = 2000.0  # Hz — ABF acquisition rate
+
+
+class Chen2026ABFEventsInterface(BaseEventsInterface):
+    """Camera frame-trigger and opto pulse events from the raw ABF file.
+
+    Writes two ``EventsTable`` objects in ``nwbfile.events``:
+
+    * ``CameraFrameTrigger`` — ~129 k timestamp-only point events (one per frame).
+    * ``OptoPulse``          — ~2048 interval events (onset + duration for each
+      individual optogenetic pulse; 32 pulses × 64 trains).
+    """
+
+    display_name = "Chen2026 ABF Events (camera trigger + opto pulses)"
+    associated_suffixes = (".abf",)
+    info = "Interface for camera frame-trigger and optogenetic pulse events from the ABF file."
+
+    metadata_key = "ABFEvents"
+
+    def __init__(self, *, file_path: str | Path, verbose: bool = False):
+        super().__init__(file_path=str(file_path), verbose=verbose)
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+        metadata.setdefault("Events", {})[self.metadata_key] = {
+            "event_types": {
+                "camera_trigger": {
+                    "event_name": "CameraFrameTrigger",
+                    "event_description": ("Rising edge of the camera frame-sync TTL."),
+                },
+                "opto_pulse": {
+                    "event_name": "OptoTTL",
+                    "event_description": (
+                        "Individual optogenetic pulse from the raw ABF opto_TTL channel (2000 Hz, "
+                        "threshold 0.01 V). Each row is one TTL-high pulse; start_time is the rising "
+                        "edge and duration is the pulse width. Complements the train-level "
+                        "OptogeneticEpochsTable: epochs 0-31 (~1.2 V) have 32 pulses at ~9 ms each; "
+                        "epochs 32-63 (~0.05 V) have 32 pulses at ~8 ms each."
+                    ),
+                },
+            }
+        }
+        return metadata
+
+    def _get_events_data_dict(self) -> dict[str, _EventsData]:
+        if self._events_data_dict is not None:
+            return self._events_data_dict
+
+        import pyabf
+
+        abf = pyabf.ABF(self.source_data["file_path"], loadData=True)
+        channel_names = [abf.adcNames[i].strip() for i in range(abf.channelCount)]
+
+        # ── camera frame trigger (point events) ──────────────────────────────
+        cam_idx = channel_names.index("camera")
+        cam = abf.data[cam_idx]
+        above_cam = cam > _CAMERA_THRESHOLD_V
+        cam_rising = np.where(np.diff(above_cam.astype(np.int8)) == 1)[0]
+        cam_timestamps = cam_rising / _SAMPLE_RATE
+
+        # ── opto pulse (interval events) ─────────────────────────────────────
+        opto_idx = channel_names.index("opto_TTL")
+        opto = abf.data[opto_idx]
+        above_opto = opto > _OPTO_THRESHOLD_V
+        diff_opto = np.diff(above_opto.astype(np.int8))
+        rising = np.where(diff_opto == 1)[0]
+        falling = np.where(diff_opto == -1)[0]
+
+        # Align rising/falling pairs: discard an unpaired leading falling edge
+        if len(falling) and len(rising) and falling[0] < rising[0]:
+            falling = falling[1:]
+        n_pulses = min(len(rising), len(falling))
+        rising = rising[:n_pulses]
+        falling = falling[:n_pulses]
+
+        opto_timestamps = rising / _SAMPLE_RATE
+        opto_durations = (falling - rising) / _SAMPLE_RATE
+
+        self._events_data_dict = {
+            "camera_trigger": _EventsData(
+                event_type_source_id="camera_trigger",
+                timestamps=cam_timestamps,
+            ),
+            "opto_pulse": _EventsData(
+                event_type_source_id="opto_pulse",
+                timestamps=opto_timestamps,
+                durations=opto_durations,
+            ),
+        }
+        return self._events_data_dict

--- a/src/dombeck_lab_to_nwb/chen2026/interfaces/events_interface.py
+++ b/src/dombeck_lab_to_nwb/chen2026/interfaces/events_interface.py
@@ -1,9 +1,9 @@
 """Raw ABF events interface for Chen et al. 2026 (LRRK2 dataset).
 
 Reads the opto_TTL channel from the raw ABF file and writes individual
-optogenetic pulses as an ``OptoPulse`` ``EventsTable`` in ``nwbfile.events``.
+optogenetic pulses as an ``OptoTTL`` ``EventsTable`` in ``nwbfile.events``.
 
-  OptoPulse — individual optogenetic pulses (interval events)
+  OptoTTL — individual optogenetic pulses (interval events)
       (ABF channel 'opto_TTL', 2000 Hz)
       Pulse-level events complementing the train-level OptogeneticEpochsTable.
       Both halves of the session are detectable at 2 kHz (threshold 0.01 V):
@@ -31,7 +31,7 @@ class Chen2026ABFEventsInterface(BaseEventsInterface):
 
     Writes one ``EventsTable`` in ``nwbfile.events``:
 
-    * ``OptoPulse`` — ~2048 interval events (onset + duration per pulse;
+    * ``OptoTTL`` — ~2048 interval events (onset + duration per pulse;
       32 pulses × 64 trains). Complements the train-level
       ``OptogeneticEpochsTable`` in ``nwbfile.intervals``.
     """

--- a/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
+++ b/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
@@ -1,6 +1,7 @@
 from neuroconv import NWBConverter
 
 from .interfaces import (
+    Chen2026ABFEventsInterface,
     Chen2026BehaviorInterface,
     Chen2026OptogeneticsInterface,
     Chen2026ProcessedFiberPhotometryInterface,
@@ -15,6 +16,7 @@ class Chen2026NWBConverter(NWBConverter):
     Raw interfaces (always present):
       RawSignal              — 470 nm demultiplexed from ABF
       IsosbesticControl      — 405 nm demultiplexed from ABF
+      ABFEvents              — camera frame-trigger + opto pulses (EventsTable)
 
     Processed interfaces (present when a *_data.mat file is provided):
       CorrectedSignal        — baseline-corrected 470 nm (corrected470, 100 Hz)
@@ -28,6 +30,7 @@ class Chen2026NWBConverter(NWBConverter):
     data_interface_classes = dict(
         RawSignal=Chen2026RawFiberPhotometryInterface,
         IsosbesticControl=Chen2026RawFiberPhotometryInterface,
+        ABFEvents=Chen2026ABFEventsInterface,
         CorrectedSignal=Chen2026ProcessedFiberPhotometryInterface,
         CorrectedIsosbestic=Chen2026ProcessedFiberPhotometryInterface,
         DfOverF=Chen2026ProcessedFiberPhotometryInterface,

--- a/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
+++ b/src/dombeck_lab_to_nwb/chen2026/nwbconverter.py
@@ -16,7 +16,7 @@ class Chen2026NWBConverter(NWBConverter):
     Raw interfaces (always present):
       RawSignal              — 470 nm demultiplexed from ABF
       IsosbesticControl      — 405 nm demultiplexed from ABF
-      ABFEvents              — camera frame-trigger + opto pulses (EventsTable)
+      ABFEvents              — individual opto pulses from raw opto_TTL (EventsTable)
 
     Processed interfaces (present when a *_data.mat file is provided):
       CorrectedSignal        — baseline-corrected 470 nm (corrected470, 100 Hz)


### PR DESCRIPTION
Adds Raw ABF events interface for Chen et al. 2026 (LRRK2 dataset).

Example file for reference: [sub-302-calb-gs_ses-2025-11-10-0005.nwb](https://drive.google.com/file/d/1tMl3zA9tihh0sSI6mupF57dOdjzgw8ue/view?usp=drive_link)

Tutorial notebook [here](https://github.com/catalystneuro/dombeck-lab-to-nwb/blob/82550db4f4ae1d32f60f9c3ab5f5ac73bff50b96/src/dombeck_lab_to_nwb/chen2026/tutorials/chen2026_demo.ipynb
) to aid the review.

- Reads the opto_TTL channel from the raw ABF file and writes individual optogenetic pulses as an ``OptoTTL`` ``EventsTable`` in ``nwbfile.events``.

- OptoTTL — individual optogenetic pulses (interval events) (ABF channel 'opto_TTL', 2000 Hz)
- Pulse-level events complementing the train-level OptogeneticEpochsTable.
- Both halves of the session are detectable at 2 kHz (threshold 0.01 V): 
- epochs 0-31  (~1.2 V): 32 pulses per train, 9 ms on / 1 ms off
- epochs 32-63 (~0.05 V): 32 pulses per train, 8 ms on / 8 ms off

Note: camera frame trigger times are not stored as a separate EventsTable because
they are already the explicit timestamps of every 100 Hz processed series
(corrected FP, ΔF/F, velocity, acceleration) and duplicating ~129k rows would
add significant write time without new information.